### PR TITLE
Fix in CallExternalCommand: Exception message "Error calling external…

### DIFF
--- a/GreenshotExternalCommandPlugin/ExternalCommandDestination.cs
+++ b/GreenshotExternalCommandPlugin/ExternalCommandDestination.cs
@@ -121,7 +121,7 @@ namespace ExternalCommand {
 						if (config.OutputToClipboard) {
 							ClipboardHelper.SetClipboardData(output);
 						}
-						if (uriMatches != null && uriMatches.Count >= 0) {
+						if (uriMatches != null && uriMatches.Count > 0) {
 							exportInformation.Uri = uriMatches[0].Groups[1].Value;
 							LOG.InfoFormat("Got URI : {0} ", exportInformation.Uri);
 							if (config.UriToClipboard) {
@@ -134,10 +134,10 @@ namespace ExternalCommand {
 					exportInformation.ExportMade = false;
 					exportInformation.ErrorMessage = error;
 				}
-			} catch (Exception ex) {
-				LOG.WarnFormat("Error calling external command: {0} ", exportInformation.ErrorMessage);
+			} catch (Exception ex) {				
 				exportInformation.ExportMade = false;
 				exportInformation.ErrorMessage = ex.Message;
+                LOG.WarnFormat("Error calling external command: {0} ", exportInformation.ErrorMessage);
 			}
 		}
 


### PR DESCRIPTION
Exception message "Error calling external command" was shown although CallExternalCommand has finished successful.

This is reproducible by creating a simple batch file containing:

_copy %1 C:\TEMP_

When adding this as external command the output of "CallExternalCommand" will be something like:

D:\WORK\greenshot\Greenshot\bin\Debug>copy "C:\Users\Jan\AppData\Local\Temp\2015_10_03_16_08_28_Greenshot_Running_Microsoft_Visual_Studio.png" C:\TEMP
        1 Datei(en) kopiert.

So output string is not empty and MatchCollection uriMatches = URI_REGEXP.Matches(output) is executed. I don't analysed what this regular expression should check, in fact uriMatches != null but uriMatches.Count is 0. There is no match, so I suppose uriMatches.Count should be > 0, not >= 0?

When accessing uriMatches[0] an System.ArgumentOutOfRangeException was raised:

Message = "Das angegebene Argument liegt außerhalb des gültigen Wertebereichs.\r\nParametername: i"

In addition log4net message has been written before exportInformation.ErrorMessage was set, so exception message was not in log file.