### PR TITLE
BUG-1762, FEATURE-964, FEATURE-860 - Skip settings torn-edge & drop shadow

### DIFF
--- a/Greenshot/Forms/ImageEditorForm.Designer.cs
+++ b/Greenshot/Forms/ImageEditorForm.Designer.cs
@@ -464,13 +464,13 @@ namespace Greenshot {
 			// 
 			this.addDropshadowToolStripMenuItem.LanguageKey = "editor_image_shadow";
 			this.addDropshadowToolStripMenuItem.Name = "addDropshadowToolStripMenuItem";
-			this.addDropshadowToolStripMenuItem.Click += new System.EventHandler(this.AddDropshadowToolStripMenuItemClick);
+			this.addDropshadowToolStripMenuItem.MouseUp += AddDropshadowToolStripMenuItemMouseUp;
 			// 
 			// tornEdgesToolStripMenuItem
 			// 
 			this.tornEdgesToolStripMenuItem.LanguageKey = "editor_torn_edge";
 			this.tornEdgesToolStripMenuItem.Name = "tornEdgesToolStripMenuItem";
-			this.tornEdgesToolStripMenuItem.Click += new System.EventHandler(this.TornEdgesToolStripMenuItemClick);
+			this.tornEdgesToolStripMenuItem.MouseUp += TornEdgesToolStripMenuItemMouseUp;
 			// 
 			// grayscaleToolStripMenuItem
 			// 

--- a/Greenshot/Forms/ImageEditorForm.cs
+++ b/Greenshot/Forms/ImageEditorForm.cs
@@ -839,13 +839,13 @@ namespace Greenshot {
 						RedoToolStripMenuItemClick(sender, e);
 						break;
 					case Keys.Q:	// Dropshadow Ctrl + Q
-						AddDropshadowToolStripMenuItemClick(sender, e);
+						AddDropshadowToolStripMenuItemMouseUp(sender, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
 						break;
 					case Keys.B:	// Border Ctrl + B
 						AddBorderToolStripMenuItemClick(sender, e);
 						break;
 					case Keys.T:	// Torn edge Ctrl + T
-						TornEdgesToolStripMenuItemClick(sender, e);
+						TornEdgesToolStripMenuItemMouseUp(sender, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
 						break;
 					case Keys.I:	// Invert Ctrl + I
 						InvertToolStripMenuItemClick(sender, e);
@@ -1345,16 +1345,31 @@ namespace Greenshot {
 		/// This is used when the dropshadow button is used
 		/// </summary>
 		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void AddDropshadowToolStripMenuItemClick(object sender, EventArgs e) {
-			DropShadowEffect dropShadowEffect = EditorConfiguration.DropShadowEffectSettings;
-			// TODO: Use the dropshadow settings form to make it possible to change the default values
-			DialogResult result = new DropShadowSettingsForm(dropShadowEffect).ShowDialog(this);
-			if (result == DialogResult.OK) {
+		/// <param name="e">MouseEventArgs</param>
+		private void AddDropshadowToolStripMenuItemMouseUp(object sender, MouseEventArgs e)
+		{
+			var dropShadowEffect = EditorConfiguration.DropShadowEffectSettings;
+			bool apply;
+			switch (e.Button)
+			{
+				case MouseButtons.Left:
+					apply = true;
+					break;
+				case MouseButtons.Right:
+					var result = new DropShadowSettingsForm(dropShadowEffect).ShowDialog(this);
+					apply = result == DialogResult.OK;
+					break;
+				default:
+					return;
+			}
+		
+			if (apply)
+			{
 				_surface.ApplyBitmapEffect(dropShadowEffect);
 				UpdateUndoRedoSurfaceDependencies();
 			}
 		}
+
 
 		/// <summary>
 		/// Open the resize settings from, and resize if ok was pressed
@@ -1362,9 +1377,8 @@ namespace Greenshot {
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
 		private void BtnResizeClick(object sender, EventArgs e) {
-			ResizeEffect resizeEffect = new ResizeEffect(_surface.Image.Width, _surface.Image.Height, true);
-			// TODO: Use the Resize SettingsForm to make it possible to change the default values
-			DialogResult result = new ResizeSettingsForm(resizeEffect).ShowDialog(this);
+			var resizeEffect = new ResizeEffect(_surface.Image.Width, _surface.Image.Height, true);
+			var result = new ResizeSettingsForm(resizeEffect).ShowDialog(this);
 			if (result == DialogResult.OK) {
 				_surface.ApplyBitmapEffect(resizeEffect);
 				UpdateUndoRedoSurfaceDependencies();
@@ -1372,15 +1386,29 @@ namespace Greenshot {
 		}
 
 		/// <summary>
-		/// Call the torn edge effect
+		/// This is used when the torn-edge button is used
 		/// </summary>
 		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void TornEdgesToolStripMenuItemClick(object sender, EventArgs e) {
-			TornEdgeEffect tornEdgeEffect = EditorConfiguration.TornEdgeEffectSettings;
-			// TODO: Use the dropshadow settings form to make it possible to change the default values
-			DialogResult result = new TornEdgeSettingsForm(tornEdgeEffect).ShowDialog(this);
-			if (result == DialogResult.OK) {
+		/// <param name="e">MouseEventArgs</param>
+		private void TornEdgesToolStripMenuItemMouseUp(object sender, MouseEventArgs e)
+		{
+			var tornEdgeEffect = EditorConfiguration.TornEdgeEffectSettings;
+			bool apply;
+			switch (e.Button)
+			{
+				case MouseButtons.Left:
+					apply = true;
+					break;
+				case MouseButtons.Right:
+					var result = new TornEdgeSettingsForm(tornEdgeEffect).ShowDialog(this);
+					apply = result == DialogResult.OK;
+					break;
+				default:
+					return;
+			}
+
+			if (apply)
+			{
 				_surface.ApplyBitmapEffect(tornEdgeEffect);
 				UpdateUndoRedoSurfaceDependencies();
 			}

--- a/Greenshot/releases/additional_files/readme.txt.template
+++ b/Greenshot/releases/additional_files/readme.txt.template
@@ -10,6 +10,7 @@ All details to our tickets can be found here: https://greenshot.atlassian.net
 @DETAILVERSION@
 
 Fixed:
+* BUG-1762: Dropshadow & tornedge prompts for settings every time (now left mouse applies, right shows settings)
 * BUG-1812: Opening the editor after removing a monitor shows it outside the visible screen.
 * BUG-1876: Already running message, multi user environment
 * BUG-1884: OCR has trailing blank spaces


### PR DESCRIPTION
Add right click on drop-shadow or torn-edge brings up the settings, left-click or the hotkey (Ctrl + Q for Dropshadow, Ctrl + T for Torn-Edge) will apply directly with the previous/default settings.