### PR TITLE
Added canonical link to getgreenshot.org

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,6 +22,8 @@
    
     <script src="{{ '/js/vendor/jquery-3.1.1.min.js' | prepend: site.baseurl }}"></script>
     <script src="{{ '/js/vendor/jquery.slides.min.js' | prepend: site.baseurl }}"></script>
+	
+    <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html','' }}">
     
     <script type="text/javascript">
         var _gaq = _gaq || [];


### PR DESCRIPTION
Head now includes link rel="canonical" element, so that public forks of the repo (duplicating our content) don't hurt our search engine ranking.