### PR TITLE
Fixing the hyperlink in the README to correctly link to support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and a lot more options simplyfying creation of and work with screenshots every d
 Being easy to understand and configurable, Greenshot is an efficient tool for project managers, software developers, technical writers, testers and anyone else creating screenshots.
 
 
-[If you find that Greenshot saves you a lot of time and/or money, you are very welcome to support the development of this screenshot software.](http://getgreenshot.org/support-greenshot/)
+[If you find that Greenshot saves you a lot of time and/or money, you are very welcome to support the development of this screenshot software.](http://getgreenshot.org/support/)
 
 
 About this repository


### PR DESCRIPTION
The current hyperlink in the README links to http://getgreenshot.org/support-greenshot/ (which 404s) while the actual support link is http://getgreenshot.org/support/. This pull request simply updates that link in the README file.