### PR TITLE
Being able to set window title in the image editor.

### DIFF
--- a/Greenshot/Forms/ImageEditorForm.Designer.cs
+++ b/Greenshot/Forms/ImageEditorForm.Designer.cs
@@ -119,6 +119,7 @@ namespace Greenshot {
 			this.saveElementsToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
 			this.loadElementsToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
 			this.pluginToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
+			this.titleToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
 			this.helpToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
 			this.helpToolStripMenuItem1 = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
 			this.aboutToolStripMenuItem = new GreenshotPlugin.Controls.GreenshotToolStripMenuItem();
@@ -537,6 +538,7 @@ namespace Greenshot {
 									this.editToolStripMenuItem,
 									this.objectToolStripMenuItem,
 									this.pluginToolStripMenuItem,
+									this.titleToolStripMenuItem,
 									this.helpToolStripMenuItem});
 			this.menuStrip1.Name = "menuStrip1";
 			this.menuStrip1.BackColor = System.Drawing.SystemColors.Control;
@@ -831,6 +833,13 @@ namespace Greenshot {
 			this.pluginToolStripMenuItem.Name = "pluginToolStripMenuItem";
 			this.pluginToolStripMenuItem.Text = "Plugins";
 			this.pluginToolStripMenuItem.Visible = false;
+			// 
+			// titleToolStripMenuItem
+			// 
+			this.titleToolStripMenuItem.Name = "titleToolStripMenuItem";
+			this.titleToolStripMenuItem.Size = new System.Drawing.Size(42, 20);
+			this.titleToolStripMenuItem.Text = "Title";
+			this.titleToolStripMenuItem.Click += new System.EventHandler(this.titleToolStripMenuItem_Click);
 			// 
 			// helpToolStripMenuItem
 			// 
@@ -1743,6 +1752,7 @@ namespace Greenshot {
 		private GreenshotPlugin.Controls.GreenshotToolStripButton btnHelp;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
 		private GreenshotPlugin.Controls.GreenshotToolStripMenuItem aboutToolStripMenuItem;
+		private GreenshotPlugin.Controls.GreenshotToolStripMenuItem titleToolStripMenuItem;
 		private GreenshotPlugin.Controls.GreenshotToolStripMenuItem helpToolStripMenuItem1;
 		private GreenshotPlugin.Controls.GreenshotToolStripMenuItem helpToolStripMenuItem;
 		private GreenshotPlugin.Controls.GreenshotToolStripMenuItem preferencesToolStripMenuItem;

--- a/Greenshot/Forms/ImageEditorForm.cs
+++ b/Greenshot/Forms/ImageEditorForm.cs
@@ -1480,5 +1480,12 @@ namespace Greenshot {
 				canvas.Top = offsetY + 0;
 			}
 		}
+
+		private void titleToolStripMenuItem_Click(object sender, EventArgs e) {
+			var dialog = new TitleDialog {Title = Text};
+			if (dialog.ShowDialog() == DialogResult.OK) {
+				Text = dialog.Title;
+			}
+		}
 	}
 }

--- a/Greenshot/Forms/TitleDialog.Designer.cs
+++ b/Greenshot/Forms/TitleDialog.Designer.cs
@@ -1,0 +1,67 @@
+﻿namespace Greenshot.Forms {
+	partial class TitleDialog {
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing) {
+			if (disposing && (components != null)) {
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent() {
+			this.textboxTitle = new System.Windows.Forms.TextBox();
+			this.btnOK = new System.Windows.Forms.Button();
+			this.SuspendLayout();
+			// 
+			// textboxTitle
+			// 
+			this.textboxTitle.Location = new System.Drawing.Point(13, 13);
+			this.textboxTitle.Name = "textboxTitle";
+			this.textboxTitle.Size = new System.Drawing.Size(360, 20);
+			this.textboxTitle.TabIndex = 0;
+			this.textboxTitle.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textboxTitle_KeyPress);
+			// 
+			// btnOK
+			// 
+			this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.btnOK.Location = new System.Drawing.Point(126, 42);
+			this.btnOK.Name = "btnOK";
+			this.btnOK.Size = new System.Drawing.Size(75, 23);
+			this.btnOK.TabIndex = 1;
+			this.btnOK.Text = "OK";
+			this.btnOK.UseVisualStyleBackColor = true;
+			// 
+			// TitleDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(390, 77);
+			this.Controls.Add(this.btnOK);
+			this.Controls.Add(this.textboxTitle);
+			this.Name = "TitleDialog";
+			this.Text = "Image editor title";
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.TextBox textboxTitle;
+		private System.Windows.Forms.Button btnOK;
+	}
+}

--- a/Greenshot/Forms/TitleDialog.cs
+++ b/Greenshot/Forms/TitleDialog.cs
@@ -1,0 +1,26 @@
+﻿using System.Windows.Forms;
+
+namespace Greenshot.Forms
+{
+	public partial class TitleDialog : Form {
+		public TitleDialog() {
+			InitializeComponent();
+		}
+
+		public string Title {
+			get {
+				return textboxTitle.Text;
+			}
+			set {
+				textboxTitle.Text = value;
+			}
+		}
+
+		private void textboxTitle_KeyPress(object sender, KeyPressEventArgs e) {
+			if (e.KeyChar == (char)Keys.Return) {
+				DialogResult = DialogResult.OK;
+				Close();
+			}
+		}
+	}
+}

--- a/Greenshot/Forms/TitleDialog.resx
+++ b/Greenshot/Forms/TitleDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Greenshot/Greenshot.csproj
+++ b/Greenshot/Greenshot.csproj
@@ -162,6 +162,12 @@
     <Compile Include="Forms\ResizeSettingsForm.Designer.cs">
       <DependentUpon>ResizeSettingsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\TitleDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\TitleDialog.Designer.cs">
+      <DependentUpon>TitleDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\TornEdgeSettingsForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
When I have a lot of image editors open, which is the case when I have created some screenshots that I dont want to close, all of those editors window titles reads "Greenshot image editor". Then I have to search for the right window in the taskbar by clicking them one by one. This change makes it possible to set a window title on each of them.