### PR TITLE
Do not show thank you page if installer was run silently

### DIFF
--- a/Greenshot/releases/innosetup/setup.iss.template
+++ b/Greenshot/releases/innosetup/setup.iss.template
@@ -651,7 +651,7 @@ end;
 Filename: "{code:getNGENPath}\ngen.exe"; Parameters: "install ""{app}\{#ExeName}.exe"""; StatusMsg: "{cm:optimize}"; Flags: runhidden runasoriginaluser
 Filename: "{code:getNGENPath}\ngen.exe"; Parameters: "install ""{app}\GreenshotPlugin.dll"""; StatusMsg: "{cm:optimize}"; Flags: runhidden runasoriginaluser
 Filename: "{app}\{#ExeName}.exe"; Description: "{cm:startgreenshot}"; Parameters: "{code:GetParamsForGS}"; WorkingDir: "{app}"; Flags: nowait postinstall runasoriginaluser
-Filename: "http://getgreenshot.org/thank-you/?language={language}&version={#Version}"; Flags: shellexec runasoriginaluser
+Filename: "http://getgreenshot.org/thank-you/?language={language}&version={#Version}"; Flags: shellexec runasoriginaluser skipifsilent
 
 [InstallDelete]
 Name: {app}; Type: dirifempty;


### PR DESCRIPTION
I understand your points in http://getgreenshot.org/faq/how-can-i-avoid-greenshot-opening-a-browser-window-at-the-end-of-the-installation-process/

But can we stop showing this site for silent deployments. Reason is I as admin want to deploy always the latest version. But I do not want to disturb people. So I want so do a silent update. But if I do this with your installer a unwanted window will pop up.

BTW
Current situation is that I still deploy Version 0.8.0 where this stuff was not shown. I think thats something you also don`t like to see. ;-)