### PR TITLE
Onedrive addon improvements - UI, public&organization link type

### DIFF
--- a/src/Greenshot.Addon.OneDrive/Entities/OneDriveGetLinkRequest.cs
+++ b/src/Greenshot.Addon.OneDrive/Entities/OneDriveGetLinkRequest.cs
@@ -1,0 +1,36 @@
+﻿#region Greenshot GNU General Public License
+
+// Greenshot - a free and open source screenshot tool
+// Copyright (C) 2007-2018 Thomas Braun, Jens Klingen, Robin Krom
+// 
+// For more information see: http://getgreenshot.org/
+// The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 1 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#endregion
+
+using Newtonsoft.Json;
+
+namespace Greenshot.Addon.OneDrive.Entities
+{
+    public class OneDriveGetLinkRequest
+    {
+        [JsonProperty("type")] 
+        public string Type;
+        
+        [JsonProperty("scope")] 
+        public string Scope;
+    }
+}

--- a/src/Greenshot.Addon.OneDrive/Entities/OneDriveGetLinkResponse.cs
+++ b/src/Greenshot.Addon.OneDrive/Entities/OneDriveGetLinkResponse.cs
@@ -1,0 +1,42 @@
+﻿#region Greenshot GNU General Public License
+
+// Greenshot - a free and open source screenshot tool
+// Copyright (C) 2007-2018 Thomas Braun, Jens Klingen, Robin Krom
+// 
+// For more information see: http://getgreenshot.org/
+// The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 1 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#endregion
+
+using Newtonsoft.Json;
+
+namespace Greenshot.Addon.OneDrive.Entities
+{
+    public class OneDriveGetLinkResponse
+    {
+        [JsonProperty("id")] 
+        public string Id;
+
+        [JsonProperty("link")] 
+        public OneDriveGetLinkResponseLink Link;       
+
+        public class OneDriveGetLinkResponseLink
+        {
+            [JsonProperty("webUrl")] 
+            public string WebUrl;
+        }
+    }
+}

--- a/src/Greenshot.Addon.OneDrive/Greenshot.Addon.OneDrive.csproj
+++ b/src/Greenshot.Addon.OneDrive/Greenshot.Addon.OneDrive.csproj
@@ -164,6 +164,8 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Entities\OneDriveGetLinkRequest.cs" />
+    <Compile Include="Entities\OneDriveGetLinkResponse.cs" />
     <Compile Include="Entities\OneDriveUploadResponse.cs" />
     <Compile Include="IOneDriveConfiguration.cs" />
     <Compile Include="IOneDriveLanguage.cs" />

--- a/src/Greenshot.Addon.OneDrive/IOneDriveConfiguration.cs
+++ b/src/Greenshot.Addon.OneDrive/IOneDriveConfiguration.cs
@@ -54,9 +54,6 @@ namespace Greenshot.Addon.OneDrive
         [DefaultValue(OneDriveLinkType.@private)]
         OneDriveLinkType LinkType { get; set; }
 
-        [Description("The OneDrive refresh token")]
-        string RefreshToken { get; set; }
-
         [Description("Reduce color amount of the uploaded image to 256")]
         [DefaultValue(false)]
         bool UploadReduceColors { get; set; }

--- a/src/Greenshot.Addon.OneDrive/IOneDriveLanguage.cs
+++ b/src/Greenshot.Addon.OneDrive/IOneDriveLanguage.cs
@@ -33,27 +33,11 @@ namespace Greenshot.Addon.OneDrive
     [Language("OneDrive")]
     public interface IOneDriveLanguage : ILanguage, INotifyPropertyChanged
     {
-        string Cancel { get; }
-
-        string ClearQuestion { get; }
-
         string CommunicationWait { get; }
-
-        string Configure { get; }
-
-        string DeleteQuestion { get; }
-
-        string DeleteTitle { get; }
-
-        string History { get; }
-
-        string LabelClear { get; }
 
         string LabelUploadFormat { get; }
 
-        string LabelUrl { get; }
-
-        string Ok { get; }
+        string LabelLinkType { get; }
 
         string SettingsTitle { get; }
 
@@ -61,11 +45,6 @@ namespace Greenshot.Addon.OneDrive
 
         string UploadMenuItem { get; }
 
-        string UploadSuccess { get; }
-
         string UsePageLink { get; }
-
-        string AnonymousAccess { get; }
-
     }
 }

--- a/src/Greenshot.Addon.OneDrive/IOneDriveLanguage.cs
+++ b/src/Greenshot.Addon.OneDrive/IOneDriveLanguage.cs
@@ -46,5 +46,7 @@ namespace Greenshot.Addon.OneDrive
         string UploadMenuItem { get; }
 
         string UsePageLink { get; }
+
+        string ResetCredentialsButton { get; }
     }
 }

--- a/src/Greenshot.Addon.OneDrive/Languages/language_onedriveplugin-en-US.xml
+++ b/src/Greenshot.Addon.OneDrive/Languages/language_onedriveplugin-en-US.xml
@@ -23,5 +23,8 @@
         <resource name="label_url">
             Url
         </resource>
+        <resource name="reset_credentials_button">
+            Reset OneDrive credentials
+        </resource>
     </resources>
 </language>

--- a/src/Greenshot.Addon.OneDrive/Languages/language_onedriveplugin-en-US.xml
+++ b/src/Greenshot.Addon.OneDrive/Languages/language_onedriveplugin-en-US.xml
@@ -2,53 +2,26 @@
 
 <language>
     <resources prefix="OneDrive">
-        <resource name="upload_menu_item">
-            Upload to OneDrive
-        </resource>
-        <resource name="settings_title">
-            OneDrive settings
-        </resource>
-        <resource name="label_url">
-            Url
-        </resource>
-        <resource name="OK">
-            OK
-        </resource>
-        <resource name="CANCEL">
-            Cancel
-        </resource>
-        <resource name="upload_success">
-            Successfully uploaded image to OneDrive!
-        </resource>
-        <resource name="upload_failure">
-            An error occured while uploading to OneDrive:
+        <resource name="communication_wait">
+            Communicating with OneDrive. Please wait...
         </resource>
         <resource name="label_upload_format">
             Image format
         </resource>
-        <resource name="communication_wait">
-            Communicating with OneDrive. Please wait...
+        <resource name="label_link_type">
+            Link Type
         </resource>
-        <resource name="delete_question">
-            Are you sure you want to delete the image {0} from OneDrive?
+        <resource name="settings_title">
+            OneDrive settings
         </resource>
-        <resource name="clear_question">
-            Are you sure you want to delete the local OneDrive history?
+        <resource name="upload_failure">
+            An error occured while uploading to OneDrive:
         </resource>
-        <resource name="delete_title">
-            Delete OneDrive {0}
+        <resource name="upload_menu_item">
+            Upload to OneDrive
         </resource>
-        <resource name="anonymous_access">
-            Use anonymous access
-        </resource>
-        <resource name="use_page_link">
-            Use page link instead of image link on clipboard
-        </resource>
-        <resource name="history">
-            History
-        </resource>
-        <resource name="configure">
-            Configure
+        <resource name="label_url">
+            Url
         </resource>
     </resources>
 </language>

--- a/src/Greenshot.Addon.OneDrive/ViewModels/OneDriveConfigViewModel.cs
+++ b/src/Greenshot.Addon.OneDrive/ViewModels/OneDriveConfigViewModel.cs
@@ -87,5 +87,17 @@ namespace Greenshot.Addon.OneDrive.ViewModels
 
         public IDictionary<OutputFormats, string> UploadFormats => GreenshotLanguage.TranslationValuesForEnum<OutputFormats>();
 
+        public OneDriveLinkType SelectedLinkType
+        {
+            get => OneDriveConfiguration.LinkType;
+            set
+            {
+                OneDriveConfiguration.LinkType = value;
+                NotifyOfPropertyChange();
+            }
+        }
+
+        public IDictionary<OneDriveLinkType, string> LinkTypes => GreenshotLanguage.TranslationValuesForEnum<OneDriveLinkType>();
+
     }
 }

--- a/src/Greenshot.Addon.OneDrive/ViewModels/OneDriveConfigViewModel.cs
+++ b/src/Greenshot.Addon.OneDrive/ViewModels/OneDriveConfigViewModel.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Reactive.Disposables;
@@ -95,6 +96,24 @@ namespace Greenshot.Addon.OneDrive.ViewModels
                 OneDriveConfiguration.LinkType = value;
                 NotifyOfPropertyChange();
             }
+        }
+
+        public bool IsCredentialsButtonEnabled
+        {
+            get
+            {
+                return OneDriveConfiguration.OAuth2AccessToken != null ||
+                       OneDriveConfiguration.OAuth2RefreshToken != null;
+            }
+        }
+
+        public void CredentialsButton()
+        {
+            OneDriveConfiguration.OAuth2AccessToken = null;
+            OneDriveConfiguration.OAuth2RefreshToken = null;
+            OneDriveConfiguration.OAuth2AccessTokenExpires = DateTimeOffset.MaxValue;//how to reset this property?
+            //todo somehow notify framework that IsCredentialsButtonEnabled will return different value now, so the button gets disabled
+            NotifyOfPropertyChange();
         }
 
         public IDictionary<OneDriveLinkType, string> LinkTypes => GreenshotLanguage.TranslationValuesForEnum<OneDriveLinkType>();

--- a/src/Greenshot.Addon.OneDrive/Views/OneDriveConfigView.xaml
+++ b/src/Greenshot.Addon.OneDrive/Views/OneDriveConfigView.xaml
@@ -19,6 +19,7 @@
                     <Label Content="{Binding OneDriveLanguage.LabelLinkType}" Width="100" />
                     <ComboBox SelectedValue="{Binding SelectedLinkType}" ItemsSource="{Binding LinkTypes}" SelectedValuePath="Key" DisplayMemberPath="Value" />
                 </DockPanel>
+                <Button Content="{Binding OneDriveLanguage.ResetCredentialsButton}" IsEnabled="{Binding IsCredentialsButtonEnabled}" Name="CredentialsButton" />
             </StackPanel>
         </GroupBox>
     </StackPanel>

--- a/src/Greenshot.Addon.OneDrive/Views/OneDriveConfigView.xaml
+++ b/src/Greenshot.Addon.OneDrive/Views/OneDriveConfigView.xaml
@@ -15,7 +15,10 @@
                     <ComboBox SelectedValue="{Binding SelectedUploadFormat}" ItemsSource="{Binding UploadFormats}" SelectedValuePath="Key" DisplayMemberPath="Value" />
                 </DockPanel>
                 <CheckBox IsChecked="{Binding OneDriveConfiguration.AfterUploadLinkToClipBoard}" Content="{Binding OneDriveLanguage.UsePageLink}"/>
-                <CheckBox IsChecked="{Binding OneDriveConfiguration.AfterUploadLinkToClipBoard}" Content="{Binding OneDriveLanguage.UsePageLink}"/>
+                <DockPanel LastChildFill="True">
+                    <Label Content="{Binding OneDriveLanguage.LabelLinkType}" Width="100" />
+                    <ComboBox SelectedValue="{Binding SelectedLinkType}" ItemsSource="{Binding LinkTypes}" SelectedValuePath="Key" DisplayMemberPath="Value" />
+                </DockPanel>
             </StackPanel>
         </GroupBox>
     </StackPanel>


### PR DESCRIPTION
OneDrive improvements:

UI:
* Removed unused language properties (maybe they are needed but I just didn't know?)
* Added OneDriveLinkType selection
* Added reset credentials button

Destination:
* Support public and organization links - additional call was needed to retrieve them