### PR TITLE
Removed external test dependency

### DIFF
--- a/src/Greenshot.Tests/CaptureTests.cs
+++ b/src/Greenshot.Tests/CaptureTests.cs
@@ -20,6 +20,7 @@
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Media.Imaging;
@@ -117,7 +118,19 @@ namespace Greenshot.Tests
         {
             ICoreConfiguration config = new CoreConfigurationImpl();
 
-            var windowToCapture = InteropWindowQuery.GetTopLevelWindows().First(window => window.GetCaption().Contains("Notepad"));
+            var textValue = System.Guid.NewGuid().ToString();
+            var form = new Form
+            {
+                Text = textValue,
+                TopLevel = true
+            };
+            form.Show();
+            // Important, otherwise Windows doesn't have time to display the window!
+            Application.DoEvents();
+
+            await Task.Delay(400);
+            var windowToCapture = await WindowsEnumerator.EnumerateWindowsAsync().Where(info => info.GetCaption().Contains(textValue)).FirstOrDefaultAsync();
+
             var bounds = windowToCapture.GetInfo().Bounds;
             var captureFlow = new CaptureFlow<BitmapSource>
             {


### PR DESCRIPTION
Removed capture test being dependent on some Notepad window. Test was only successfull if this window existed (had to open it manually).

Code from [your dapplo repo](https://github.com/dapplo/Dapplo.Windows/blob/450fae4b4a139b2bf6063bbbc6c40772355d4c0d/src/Dapplo.Windows.Tests/WindowsEnumeratorTests.cs#L85)

PS: Great seeing you working on Greenshot 2.0. Keep up the good work. Thanks to your recent changes, I was finally able to finish a build. With this small change all tests are successfull now.