### PR TITLE
Fixing textbox issue with polish letter ą

### DIFF
--- a/src/Greenshot.Addon.LegacyEditor/Drawing/TextContainer.cs
+++ b/src/Greenshot.Addon.LegacyEditor/Drawing/TextContainer.cs
@@ -495,8 +495,7 @@ namespace Greenshot.Addon.LegacyEditor.Drawing
                 HideTextBox();
                 e.SuppressKeyPress = true;
             }
-
-            if (e.Control && e.KeyCode == Keys.A)
+            if (e.Control && !e.Alt && e.KeyCode == Keys.A)
             {
                 _textBox.SelectAll();
             }


### PR DESCRIPTION
Fixing issue in textbox when typing ALTGR+A (polish letter ą) raised in threads BUG-2288, BUG-2474.