### PR TITLE
Add a tooltip for file output path selection

### DIFF
--- a/src/Greenshot.Addons/Views/FileConfigPartView.xaml
+++ b/src/Greenshot.Addons/Views/FileConfigPartView.xaml
@@ -25,7 +25,7 @@
 
             <DockPanel LastChildFill="True">
                 <Label Content="{Binding GreenshotLanguage.SettingsOutput}" Width="100" />
-                <Button Content="..." Name="SelectOutputPath" ToolTip="{Binding GreenshotLanguage.SettingsOutput}/>
+                <Button Content="..." Name="SelectOutputPath" ToolTip="{Binding GreenshotLanguage.SettingsOutput}"/>
                 <TextBox Text="{Binding FileConfiguration.OutputFilePath}"/>
             </DockPanel>
             

--- a/src/Greenshot.Addons/Views/FileConfigPartView.xaml
+++ b/src/Greenshot.Addons/Views/FileConfigPartView.xaml
@@ -25,7 +25,7 @@
 
             <DockPanel LastChildFill="True">
                 <Label Content="{Binding GreenshotLanguage.SettingsOutput}" Width="100" />
-                <Button Content="..." Name="SelectOutputPath" />
+                <Button Content="..." Name="SelectOutputPath" ToolTip="{Binding GreenshotLanguage.SettingsOutput}/>
                 <TextBox Text="{Binding FileConfiguration.OutputFilePath}"/>
             </DockPanel>
             


### PR DESCRIPTION
Notes from accessibility testing:

Defect: Information is conveyed solely via a sensory characteristic.

 
Description: Please see example below for details.


Expected result: Information is expected to not rely solely on sensory characteristics such as size, shape, sound, or visual orientation. In this instance, additional information such as text or labeling is expected to be provided for the three dot button.

Reference: Section 508, 1.3.3 – Sensory Characteristics.    
For more information, visit: http://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html

Steps to reproduce:

1.       Open Greenshot v1.2.10.6
2.       Select “Preferences…” link.
3.       Navigate to the “Output” tab.

Notice that no additional information such as text or labeling is provided for the three dot button next to “Storage location” field. Instead, instructions are expected to be provided for understanding and operating content that does not rely solely on sensory characteristics such as shape, size, visual location, and orientation.