### PR TITLE
Font size field type fix

### DIFF
--- a/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/Binding/DecimalFloatConverter.cs
+++ b/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/Binding/DecimalFloatConverter.cs
@@ -1,4 +1,4 @@
-﻿// Greenshot - a free and open source screenshot tool
+// Greenshot - a free and open source screenshot tool
 // Copyright (C) 2007-2020 Thomas Braun, Jens Klingen, Robin Krom
 // 
 // For more information see: http://getgreenshot.org/
@@ -37,7 +37,7 @@ namespace Greenshot.Addon.LegacyEditor.Drawing.Fields.Binding
 
 		protected override float Convert(decimal o)
 		{
-			return System.Convert.ToInt16(o);
+			return System.Convert.ToSingle(o);
 		}
 
 		public static DecimalFloatConverter GetInstance()

--- a/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/Binding/DecimalIntConverter.cs
+++ b/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/Binding/DecimalIntConverter.cs
@@ -1,4 +1,4 @@
-﻿// Greenshot - a free and open source screenshot tool
+// Greenshot - a free and open source screenshot tool
 // Copyright (C) 2007-2020 Thomas Braun, Jens Klingen, Robin Krom
 // 
 // For more information see: http://getgreenshot.org/
@@ -37,7 +37,7 @@ namespace Greenshot.Addon.LegacyEditor.Drawing.Fields.Binding
 
 		protected override int Convert(decimal o)
 		{
-			return System.Convert.ToInt16(o);
+			return System.Convert.ToInt32(o);
 		}
 
 		public static DecimalIntConverter GetInstance()

--- a/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/FieldTypes.cs
+++ b/src/Greenshot.Addon.LegacyEditor/Drawing/Fields/FieldTypes.cs
@@ -59,7 +59,7 @@ namespace Greenshot.Addon.LegacyEditor.Drawing.Fields
         /// <summary>
         /// This field specifies the font size
         /// </summary>
-	    public static readonly IFieldType FONT_SIZE = new FieldType<int>("FONT_SIZE");
+	    public static readonly IFieldType FONT_SIZE = new FieldType<float>("FONT_SIZE");
         /// <summary>
         /// This field specifies the horizontal text alignment
         /// </summary>


### PR DESCRIPTION
This looks like a copy-paste error. Font size is supposed to be a float, judging from the rest of the code. Wrong type here causes exceptions.

Side note: both DecimalIntConverter and DecimalFloatConverter also look like someone wasn't paying attention. `Decimal --> (explicit) Int16 --> (implicit) Float` conversion causes no issues only due to the fact all numbers effectively are small integers.