### PR TITLE
Fixes a minor typo in the English language files

### DIFF
--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -90,7 +90,7 @@
 		<resource name="expertsettings_optimizeforrdp">Make some optimizations for usage with remote desktop</resource>
 		<resource name="expertsettings_reuseeditorifpossible">Reuse editor if possible</resource>
 		<resource name="expertsettings_suppresssavedialogatclose">Suppress the save dialog when closing the editor</resource>
-		<resource name="expertsettings_thumbnailpreview">Show window thumbnails in context menu (for Vista and windows 7)</resource>
+		<resource name="expertsettings_thumbnailpreview">Show window thumbnails in context menu (for Vista and Windows 7)</resource>
 		<resource name="exported_to">Exported to: {0}</resource>
 		<resource name="exported_to_error">An error occured while exporting to {0}:</resource>
 		<resource name="help_title">Greenshot Help</resource>


### PR DESCRIPTION
Fixes a minor typo on the term 'Windows 7' in the English language files.