### PR TITLE
Fix Unicode text drawing

### DIFF
--- a/Greenshot/Drawing/TextContainer.cs
+++ b/Greenshot/Drawing/TextContainer.cs
@@ -598,6 +598,41 @@ namespace Greenshot.Drawing
             DrawText(graphics, rect, lineThickness, lineColor, drawShadow, _stringFormat, text, _font);
         }
 
+        private static TextFormatFlags ConvertStringFormat(StringFormat stringFormat)
+        {
+            TextFormatFlags flags = TextFormatFlags.Default;
+            if (stringFormat == null)
+            {
+                return flags;
+            }
+            switch (stringFormat.LineAlignment)
+            {
+                case StringAlignment.Center:
+                    flags |= TextFormatFlags.VerticalCenter;
+                    break;
+                case StringAlignment.Far:
+                    flags |= TextFormatFlags.Bottom;
+                    break;
+                case StringAlignment.Near:
+                    flags |= TextFormatFlags.Top;
+                    break;
+            }
+            switch (stringFormat.Alignment)
+            {
+                case StringAlignment.Center:
+                    flags |= TextFormatFlags.HorizontalCenter;
+                    break;
+                case StringAlignment.Far:
+                    flags |= TextFormatFlags.Right;
+                    break;
+                case StringAlignment.Near:
+                    flags |= TextFormatFlags.Left;
+                    break;
+            }
+
+            return flags;
+        }
+
         /// <summary>
         /// This method can be used from other containers
         /// </summary>
@@ -636,8 +671,8 @@ namespace Greenshot.Drawing
                         shadowRect.Inflate(-textOffset, -textOffset);
                     }
 
-                    using Brush fontBrush = new SolidBrush(Color.FromArgb(alpha, 100, 100, 100));
-                    graphics.DrawString(text, font, fontBrush, shadowRect, stringFormat);
+                    TextRenderer.DrawText(graphics, text, font, shadowRect, Color.FromArgb(alpha, 100, 100, 100), ConvertStringFormat(stringFormat));
+
                     currentStep++;
                     alpha -= basealpha / steps;
                 }
@@ -647,16 +682,14 @@ namespace Greenshot.Drawing
             {
                 drawingRectange.Inflate(-textOffset, -textOffset);
             }
-            using (Brush fontBrush = new SolidBrush(fontColor))
+
+            if (stringFormat != null)
             {
-                if (stringFormat != null)
-                {
-                    graphics.DrawString(text, font, fontBrush, drawingRectange, stringFormat);
-                }
-                else
-                {
-                    graphics.DrawString(text, font, fontBrush, drawingRectange);
-                }
+                TextRenderer.DrawText(graphics, text, font, drawingRectange, fontColor, ConvertStringFormat(stringFormat));
+            }
+            else
+            {
+                TextRenderer.DrawText(graphics, text, font, drawingRectange, fontColor);
             }
         }
 


### PR DESCRIPTION
In #283 it was reported that Greenshot doesn't draw unicode icons correctly. this should solve it.