### PR TITLE
Fix Ellipse and Highlight duplication bug (#322).

### DIFF
--- a/src/Greenshot.Editor/Drawing/EllipseContainer.cs
+++ b/src/Greenshot.Editor/Drawing/EllipseContainer.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Runtime.Serialization;
 using Greenshot.Base.Interfaces.Drawing;
 using Greenshot.Editor.Drawing.Fields;
 using Greenshot.Editor.Helpers;
@@ -35,6 +36,17 @@ namespace Greenshot.Editor.Drawing
     public class EllipseContainer : DrawableContainer
     {
         public EllipseContainer(Surface parent) : base(parent)
+        {
+            Init();
+        }
+
+        protected override void OnDeserialized(StreamingContext streamingContext)
+        {
+            base.OnDeserialized(streamingContext);
+            Init();
+        }
+
+        private void Init()
         {
             CreateDefaultAdorners();
         }

--- a/src/Greenshot.Editor/Drawing/HighlightContainer.cs
+++ b/src/Greenshot.Editor/Drawing/HighlightContainer.cs
@@ -56,6 +56,7 @@ namespace Greenshot.Editor.Drawing
         {
             FieldChanged += HighlightContainer_OnFieldChanged;
             ConfigurePreparedFilters();
+            CreateDefaultAdorners();
         }
 
         protected void HighlightContainer_OnFieldChanged(object sender, FieldChangedEventArgs e)


### PR DESCRIPTION
Fixes #322.

Ellipse only created default adorners in constructor, never after deserialization. Having zero adorners triggered a Linq exception down the code path. Fixed by duplicating the deserialization logic from RectangleContainer.

Highlight also failed to create its default adorners. Fixed by just adding a correct call to CreateDefaultAdorners in the existing Init method.