### PR TITLE
prevent negative fontsize

### DIFF
--- a/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
+++ b/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
@@ -204,7 +204,7 @@ namespace Greenshot.Editor.Drawing
                 EllipseContainer.DrawEllipse(rect, graphics, rm, 0, Color.Transparent, fillColor, false);
             }
 
-            float fontSize = Math.Min(Width, Height) / 1.4f;
+            float fontSize = Math.Min(Math.Abs(Width), Math.Abs(Height)) / 1.4f;
             using FontFamily fam = new FontFamily(FontFamily.GenericSansSerif.Name);
             using Font font = new Font(fam, fontSize, FontStyle.Bold, GraphicsUnit.Pixel);
             TextContainer.DrawText(graphics, rect, 0, lineColor, false, _stringFormat, text, font);


### PR DESCRIPTION
Fix for Bug while rotating screenshot with counters.

Old:
![Rotate_bug_1](https://user-images.githubusercontent.com/32000301/154755788-1c4d288a-70a0-48e8-8072-01caa841c99a.png)
![Rotate_bug_2](https://user-images.githubusercontent.com/32000301/154755803-10ba10b3-4dc8-4cd9-b6de-bb95c376e078.png)

New:
![Rotate_bug_3](https://user-images.githubusercontent.com/32000301/154755833-5985d6cb-1521-454b-a0cb-4516a562d49d.png)

