### PR TITLE
IsConfirmable for IDrawableContainer

### DIFF
--- a/src/Greenshot.Base/Interfaces/Drawing/IDrawableContainer.cs
+++ b/src/Greenshot.Base/Interfaces/Drawing/IDrawableContainer.cs
@@ -94,6 +94,11 @@ namespace Greenshot.Base.Interfaces.Drawing
         IList<IAdorner> Adorners { get; }
 
         /// <summary>
+        /// Is confirm/cancel possible for this container
+        /// </summary>
+        bool IsConfirmable { get; }
+
+        /// <summary>
         /// Adjust UI elements to the supplied DPI settings
         /// </summary>
         /// <param name="dpi">uint</param>

--- a/src/Greenshot.Editor/Drawing/CropContainer.cs
+++ b/src/Greenshot.Editor/Drawing/CropContainer.cs
@@ -264,9 +264,18 @@ namespace Greenshot.Editor.Drawing
             Invalidate();
             return true;
         }
-
-        /// <inheritdoc cref="IDrawableContainer"/>
+        /// <summary>
+        /// <inheritdoc />
+        /// <para/>
         /// Make sure this container is not undoable
+        /// </summary>
         public override bool IsUndoable => false;
+
+        /// <summary>
+        /// <inheritdoc />
+        /// <para/>
+        /// See dedicated confirm method <see cref="Surface.ConfirmCrop(bool)"/>
+        /// </summary>
+        public override bool IsConfirmable => true;
     }
 }

--- a/src/Greenshot.Editor/Drawing/DrawableContainer.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainer.cs
@@ -480,8 +480,11 @@ namespace Greenshot.Editor.Drawing
             g.DrawRectangle(pen, rect);
         }
 
-        /// <inheritdoc cref="IDrawableContainer"/>
+        /// <inheritdoc/>
         public virtual bool IsUndoable => true;
+
+        /// <inheritdoc/>
+        public virtual bool IsConfirmable => false;
 
         /// <summary>
         /// Make a following bounds change on this drawablecontainer undoable!

--- a/src/Greenshot.Editor/Drawing/Surface.cs
+++ b/src/Greenshot.Editor/Drawing/Surface.cs
@@ -2108,7 +2108,7 @@ namespace Greenshot.Editor.Drawing
         {
             // create new collection so that we can iterate safely (selectedElements might change due with confirm/cancel)
             List<IDrawableContainer> selectedDCs = new List<IDrawableContainer>(selectedElements);
-            foreach (IDrawableContainer dc in selectedDCs)
+            foreach (IDrawableContainer dc in selectedDCs.Where(c => c.IsConfirmable))
             {                
                 throw new NotImplementedException($"No confirm/cancel defined for Container type {dc.GetType()}");               
             }


### PR DESCRIPTION
Property IsConfirmable added for IDrawableContainer to indicate whether confirm/cancel is available.
To avoid System.NotImplementedException when pressing esc/enter on a container that does not support it.

Solve #397