### PR TITLE
Fix initial crop selection

### DIFF
--- a/src/Greenshot.Editor/Drawing/CropContainer.cs
+++ b/src/Greenshot.Editor/Drawing/CropContainer.cs
@@ -247,10 +247,11 @@ namespace Greenshot.Editor.Drawing
                         _boundsAfterResize = new NativeRectFloat(
                             _boundsBeforeResize.Left, _boundsBeforeResize.Top,
                             x - _boundsAfterResize.Left, y - _boundsAfterResize.Top);
+
+                        _boundsAfterResize = ScaleHelper.Scale(_boundsAfterResize, Positions.TopLeft, x, y, GetAngleRoundProcessor());
                         break;
                     }
             }
-            _boundsAfterResize = ScaleHelper.Scale(_boundsBeforeResize, Positions.TopLeft, x, y, GetAngleRoundProcessor());
 
             // apply scaled bounds to this DrawableContainer
             ApplyBounds(_boundsAfterResize);


### PR DESCRIPTION
Bugfix crop selection scaling #404

Disable scaling for horizontal and vertical crop modes, as it makes no sense in these cases.


Btw, but I think this is known as I read the last commit. The centered scaling does nothing. It inflates the rectangle all times by 0.