### PR TITLE
Added a "Color Picker to Clipboard" Button

### DIFF
--- a/src/Greenshot.Base/Interfaces/DrawingModes.cs
+++ b/src/Greenshot.Base/Interfaces/DrawingModes.cs
@@ -24,6 +24,7 @@ namespace Greenshot.Base.Interfaces
     public enum DrawingModes
     {
         None,
+        ColorPicker,
         Rect,
         Ellipse,
         Text,

--- a/src/Greenshot.Editor/Controls/Pipette.cs
+++ b/src/Greenshot.Editor/Controls/Pipette.cs
@@ -65,7 +65,7 @@ namespace Greenshot.Editor.Controls
         /// <param name="hotspotX">Hotspot X coordinate</param>
         /// <param name="hotspotY">Hotspot Y coordinate</param>
         /// <returns>Cursor</returns>
-        private static Cursor CreateCursor(Bitmap bitmap, int hotspotX, int hotspotY)
+        public static Cursor CreateCursor(Bitmap bitmap, int hotspotX, int hotspotY)
         {
             using SafeIconHandle iconHandle = new SafeIconHandle(bitmap.GetHicon());
             NativeIconMethods.GetIconInfo(iconHandle, out var iconInfo);

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
@@ -60,7 +60,8 @@ namespace Greenshot.Editor.Forms {
 			this.panel1 = new NonJumpingPanel();
 			this.toolsToolStrip = new ToolStripEx();
 			this.btnCursor = new GreenshotToolStripButton();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.btnColorPicker = new GreenshotToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
 			this.btnRect = new GreenshotToolStripButton();
 			this.btnEllipse = new GreenshotToolStripButton();
 			this.btnLine = new GreenshotToolStripButton();
@@ -327,7 +328,8 @@ namespace Greenshot.Editor.Forms {
 			this.toolsToolStrip.Renderer = new CustomToolStripProfessionalRenderer();
 			this.toolsToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
 									this.btnCursor,
-									this.toolStripSeparator1,
+                                    this.btnColorPicker,
+                                    this.toolStripSeparator1,
 									this.btnRect,
 									this.btnEllipse,
 									this.btnLine,
@@ -362,10 +364,20 @@ namespace Greenshot.Editor.Forms {
 			this.btnCursor.LanguageKey = "editor_cursortool";
 			this.btnCursor.Name = "btnCursor";
 			this.btnCursor.Click += new System.EventHandler(this.BtnCursorClick);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
+            // 
+            // btnColorPicker
+            // 
+            this.btnColorPicker.CheckOnClick = true;
+            this.btnColorPicker.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.btnColorPicker.Image = ((System.Drawing.Image)(resources.GetObject("colorPicker.Image")));
+            this.btnColorPicker.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.btnColorPicker.LanguageKey = "colorpicker_title";
+            this.btnColorPicker.Name = "btnColorPicker";
+            this.btnColorPicker.Click += new System.EventHandler(this.BtnColorPickerClick);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
 			// 
 			// btnRect
 			// 
@@ -1969,7 +1981,8 @@ namespace Greenshot.Editor.Forms {
 		private GreenshotToolStripMenuItem upOneLevelToolStripMenuItem;
 		private GreenshotToolStripMenuItem arrangeToolStripMenuItem;
 		private GreenshotToolStripButton btnCursor;
-		private ToolStripEx toolsToolStrip;
+        private GreenshotToolStripButton btnColorPicker;
+        private ToolStripEx toolsToolStrip;
 		private GreenshotToolStripButton btnArrow;
 		private GreenshotToolStripMenuItem drawArrowToolStripMenuItem;
 		private GreenshotToolStripMenuItem drawFreehandToolStripMenuItem;

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -285,7 +285,7 @@ namespace Greenshot.Editor.Forms
 
             _toolbarButtons = new[]
             {
-                btnCursor, btnRect, btnEllipse, btnText, btnLine, btnArrow, btnFreehand, btnHighlight, btnObfuscate, btnCrop, btnStepLabel, btnSpeechBubble
+                btnCursor, btnColorPicker, btnRect, btnEllipse, btnText, btnLine, btnArrow, btnFreehand, btnHighlight, btnObfuscate, btnCrop, btnStepLabel, btnSpeechBubble
             };
             //toolbarDropDownButtons = new ToolStripDropDownButton[]{btnBlur, btnPixeliate, btnTextHighlighter, btnAreaHighlighter, btnMagnifier};
 
@@ -598,6 +598,9 @@ namespace Greenshot.Editor.Forms
                 case DrawingModes.None:
                     SetButtonChecked(btnCursor);
                     break;
+                case DrawingModes.ColorPicker:
+                    SetButtonChecked(btnColorPicker);
+                    break;
                 case DrawingModes.Ellipse:
                     SetButtonChecked(btnEllipse);
                     break;
@@ -680,6 +683,12 @@ namespace Greenshot.Editor.Forms
         private void BtnCursorClick(object sender, EventArgs e)
         {
             _surface.DrawingMode = DrawingModes.None;
+            RefreshFieldControls();
+        }
+
+        private void BtnColorPickerClick(object sender, EventArgs e)
+        {
+            _surface.DrawingMode = DrawingModes.ColorPicker;
             RefreshFieldControls();
         }
 
@@ -1295,7 +1304,7 @@ namespace Greenshot.Editor.Forms
         private void RefreshFieldControls()
         {
             propertiesToolStrip.SuspendLayout();
-            if (_surface.HasSelectedElements || _surface.DrawingMode != DrawingModes.None)
+            if (_surface.HasSelectedElements || (_surface.DrawingMode != DrawingModes.None && _surface.DrawingMode != DrawingModes.ColorPicker))
             {
                 var props = (FieldAggregator)_surface.FieldAggregator;
                 btnFillColor.Visible = props.HasFieldValue(FieldType.FILL_COLOR);

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.resx
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.resx
@@ -1086,6 +1086,9 @@
   <data name="btnResize.Image" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\icons\resize.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="colorPicker.Image" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\Greenshot\icons\pipette.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>551, 17</value>
   </metadata>

--- a/src/Greenshot.Editor/Forms/MovableShowColorForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/MovableShowColorForm.Designer.cs
@@ -1,3 +1,5 @@
+using System.Windows.Forms;
+
 namespace Greenshot.Editor.Forms
 {
     partial class MovableShowColorForm


### PR DESCRIPTION
This pull request adds a button on the side of the image editor that allows the user to click anywhere on the image to extract the color of that pixel, which it then copies to the clipboard in the usual #RRGGBB hex format. 


https://user-images.githubusercontent.com/3231343/175240326-b1a37d9d-2396-4cc4-9c05-4277bb0ea415.mp4


This is a feature/tool I've been wanting to have for a while, and have never found anything that works quite the way I want. I've been using greenshot for a while now and have gotten used to using it enough that I feel like its a perfect platform for something like this. I'd understand if this feature can't be added because people might not like it and theres no way to add a way to disable it because of a lack of localization strings, but I figured I'd try and see anyway in case ya'll decide it can be added. I'm happy to make any adjustments requested. I'd like to add some buttons at the top of the screen when active that can do things like disable/enable the "#" character, and toggle between lowercase/uppercase, but I'm guessing that'd probably be a no-go because we'd need localized strings for the tooltips. Speaking of tooltips, the added button is using the same string as the existing color picker form. Hopefully thats ok?

Also, I'll acknowledge that a similar functionality already exists inside the "Color Picker" form/dialog, but the idea of this feature is that it should be easy to use and should heavily reduce the amount of clicks needed to copy a color.

Let me know what you think!