### PR TITLE
Fix of BUG2951

### DIFF
--- a/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
@@ -42,7 +42,10 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static ExcelDestination()
         {
-            ExePath = PluginUtils.GetExePath("EXCEL.EXE");
+            ExePath = PluginUtils.GetOfficeExePath("EXCEL.EXE", "Path");
+            if (ExePath == null)
+                ExePath = PluginUtils.GetExePath("EXCEL.EXE");
+
             if (ExePath != null && File.Exists(ExePath))
             {
                 WindowDetails.AddProcessToExcludeFromFreeze("excel");

--- a/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
@@ -42,7 +42,7 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static ExcelDestination()
         {
-            ExePath = PluginUtils.GetOfficeExePath("EXCEL.EXE", "Path");
+            ExePath = PluginUtils.GetOfficeExePath("EXCEL.EXE");
             if (ExePath == null)
                 ExePath = PluginUtils.GetExePath("EXCEL.EXE");
 

--- a/src/Greenshot.Plugin.Office/Destinations/OneNoteDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/OneNoteDestination.cs
@@ -41,7 +41,7 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static OneNoteDestination()
         {
-            exePath = PluginUtils.GetOfficeExePath("ONENOTE.EXE", "Path");
+            exePath = PluginUtils.GetOfficeExePath("ONENOTE.EXE");
             if (exePath == null)
                 exePath = PluginUtils.GetExePath("ONENOTE.EXE");
             if (exePath != null && File.Exists(exePath))

--- a/src/Greenshot.Plugin.Office/Destinations/OneNoteDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/OneNoteDestination.cs
@@ -41,7 +41,9 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static OneNoteDestination()
         {
-            exePath = PluginUtils.GetExePath("ONENOTE.EXE");
+            exePath = PluginUtils.GetOfficeExePath("ONENOTE.EXE", "Path");
+            if (exePath == null)
+                exePath = PluginUtils.GetExePath("ONENOTE.EXE");
             if (exePath != null && File.Exists(exePath))
             {
                 WindowDetails.AddProcessToExcludeFromFreeze("onenote");

--- a/src/Greenshot.Plugin.Office/Destinations/OutlookDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/OutlookDestination.cs
@@ -58,8 +58,9 @@ namespace Greenshot.Plugin.Office.Destinations
             {
                 IsActiveFlag = true;
             }
-
-            ExePath = PluginUtils.GetExePath("OUTLOOK.EXE");
+            ExePath = PluginUtils.GetOfficeExePath("OUTLOOK.EXE", "Path");
+            if (ExePath == null)
+                ExePath = PluginUtils.GetExePath("OUTLOOK.EXE");
             if (ExePath != null && File.Exists(ExePath))
             {
                 WindowDetails.AddProcessToExcludeFromFreeze("outlook");

--- a/src/Greenshot.Plugin.Office/Destinations/OutlookDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/OutlookDestination.cs
@@ -58,7 +58,7 @@ namespace Greenshot.Plugin.Office.Destinations
             {
                 IsActiveFlag = true;
             }
-            ExePath = PluginUtils.GetOfficeExePath("OUTLOOK.EXE", "Path");
+            ExePath = PluginUtils.GetOfficeExePath("OUTLOOK.EXE");
             if (ExePath == null)
                 ExePath = PluginUtils.GetExePath("OUTLOOK.EXE");
             if (ExePath != null && File.Exists(ExePath))

--- a/src/Greenshot.Plugin.Office/Destinations/PowerpointDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/PowerpointDestination.cs
@@ -45,7 +45,9 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static PowerpointDestination()
         {
-            ExePath = PluginUtils.GetExePath("POWERPNT.EXE");
+            ExePath = PluginUtils.GetOfficeExePath("POWERPNT.EXE", "Path");
+            if (ExePath == null)
+                ExePath = PluginUtils.GetExePath("POWERPNT.EXE");
             if (ExePath != null && File.Exists(ExePath))
             {
                 WindowDetails.AddProcessToExcludeFromFreeze("powerpnt");

--- a/src/Greenshot.Plugin.Office/Destinations/PowerpointDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/PowerpointDestination.cs
@@ -45,7 +45,7 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static PowerpointDestination()
         {
-            ExePath = PluginUtils.GetOfficeExePath("POWERPNT.EXE", "Path");
+            ExePath = PluginUtils.GetOfficeExePath("POWERPNT.EXE");
             if (ExePath == null)
                 ExePath = PluginUtils.GetExePath("POWERPNT.EXE");
             if (ExePath != null && File.Exists(ExePath))

--- a/src/Greenshot.Plugin.Office/Destinations/WordDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/WordDestination.cs
@@ -46,7 +46,7 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static WordDestination()
         {
-            ExePath = PluginUtils.GetOfficeExePath("WINWORD.EXE", "Path");
+            ExePath = PluginUtils.GetOfficeExePath("WINWORD.EXE");
             if (ExePath == null)
                 ExePath = PluginUtils.GetExePath("WINWORD.EXE");
             if (ExePath != null && !File.Exists(ExePath))

--- a/src/Greenshot.Plugin.Office/Destinations/WordDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/WordDestination.cs
@@ -46,7 +46,9 @@ namespace Greenshot.Plugin.Office.Destinations
 
         static WordDestination()
         {
-            ExePath = PluginUtils.GetExePath("WINWORD.EXE");
+            ExePath = PluginUtils.GetOfficeExePath("WINWORD.EXE", "Path");
+            if (ExePath == null)
+                ExePath = PluginUtils.GetExePath("WINWORD.EXE");
             if (ExePath != null && !File.Exists(ExePath))
             {
                 ExePath = null;


### PR DESCRIPTION
Changes to FIX BUG2951. Some newer Office installations use a different registry keys and some corporate GPOs block Office installation to write onto the Apps registry key. Changed the code so that the program looks in both the Apps path and the more standard OfficeInstall registry keys. This version was tested in Windows 8.1, Windows 10 and Windows 11 with no issues.