### PR TITLE
Allow user to add an outline and a drop shadow to the step label.

### DIFF
--- a/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
+++ b/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
@@ -147,6 +147,8 @@ namespace Greenshot.Editor.Drawing
         {
             AddField(GetType(), FieldType.FILL_COLOR, Color.DarkRed);
             AddField(GetType(), FieldType.LINE_COLOR, Color.White);
+            AddField(GetType(), FieldType.LINE_THICKNESS, 0);
+            AddField(GetType(), FieldType.SHADOW, false);
             AddField(GetType(), FieldType.FLAGS, FieldFlag.COUNTER);
         }
 
@@ -196,13 +198,16 @@ namespace Greenshot.Editor.Drawing
             var rect = new NativeRect(Left, Top, Width, Height).Normalize();
             Color fillColor = GetFieldValueAsColor(FieldType.FILL_COLOR);
             Color lineColor = GetFieldValueAsColor(FieldType.LINE_COLOR);
+            int lineThickness = GetFieldValueAsInt(FieldType.LINE_THICKNESS);
+            bool shadow = GetFieldValueAsBool(FieldType.SHADOW);
+
             if (_drawAsRectangle)
             {
-                RectangleContainer.DrawRectangle(rect, graphics, rm, 0, Color.Transparent, fillColor, false);
+                RectangleContainer.DrawRectangle(rect, graphics, rm, lineThickness, lineColor, fillColor, shadow);
             }
             else
             {
-                EllipseContainer.DrawEllipse(rect, graphics, rm, 0, Color.Transparent, fillColor, false);
+                EllipseContainer.DrawEllipse(rect, graphics, rm, lineThickness, lineColor, fillColor, shadow);
             }
 
             float fontSize = Math.Min(Math.Abs(Width), Math.Abs(Height)) / 1.4f;


### PR DESCRIPTION
Allow an outline and a drop shadow around the StepLabelContainer.

New options appear:

![image](https://user-images.githubusercontent.com/80274823/201212645-6ec696c3-6aa8-4348-891a-d0fd78dae955.png)

And the result:

![image](https://user-images.githubusercontent.com/80274823/201212591-ab3d1329-546c-4db5-8075-7d38acfac6e7.png)
