### PR TITLE
#572 Add ArrowHeadCombination to BinaryFormatterHelper

### DIFF
--- a/src/Greenshot.Editor/Helpers/BinaryFormatterHelper.cs
+++ b/src/Greenshot.Editor/Helpers/BinaryFormatterHelper.cs
@@ -54,6 +54,7 @@ namespace Greenshot.Editor.Helpers
             {"System.Collections.Generic.List`1[[Greenshot.Base.Interfaces.Drawing.IField", typeof(List<IField>)},
             {"System.Collections.Generic.List`1[[System.Drawing.Point", typeof(List<System.Drawing.Point>)},
             {"Greenshot.Editor.Drawing.ArrowContainer", typeof(ArrowContainer) },
+            {"Greenshot.Editor.Drawing.ArrowContainer+ArrowHeadCombination", typeof(ArrowContainer.ArrowHeadCombination) },
             {"Greenshot.Editor.Drawing.LineContainer", typeof(LineContainer) },
             {"Greenshot.Editor.Drawing.TextContainer", typeof(TextContainer) },
             {"Greenshot.Editor.Drawing.SpeechbubbleContainer", typeof(SpeechbubbleContainer) },


### PR DESCRIPTION
(cherry picked from commit 561cbf760754ec14da4bf8d89a86b40a4806cdd6)

Looks like this enum just got missed in the types dictionary in BinaryFormatterHelper. Should resolve #572 