### PR TITLE
Fix blank object when drawing at 66% or 75% zoom

### DIFF
--- a/src/Greenshot.Editor/Drawing/Surface.cs
+++ b/src/Greenshot.Editor/Drawing/Surface.cs
@@ -1771,14 +1771,14 @@ namespace Greenshot.Editor.Drawing
                 {
                     targetClipRectangle = targetClipRectangle
                         .ChangeX(targetClipRectangle.X - horizontalCorrection)
-                        .ChangeWidth(targetClipRectangle.Width + horizontalCorrection);
+                        .ChangeWidth(targetClipRectangle.X + horizontalCorrection);
                 }
 
                 if (verticalCorrection != 0)
                 {
                     targetClipRectangle = targetClipRectangle
                         .ChangeY(targetClipRectangle.Y - verticalCorrection)
-                        .ChangeHeight(targetClipRectangle.Height + verticalCorrection);
+                        .ChangeHeight(targetClipRectangle.Y + verticalCorrection);
                 }
             }
 


### PR DESCRIPTION
Needed to include existing rectangle's X/Y/Width/Height in the calculation of bounds when adjusting for zoom. ChangeX/Y/Width/Height just replace the value with whatever is passed in.
Fixes #511 