### PR TITLE
Extend SimpleServiceProvider, include the ability to remove services

### DIFF
--- a/src/Greenshot.Base/Core/SimpleServiceProvider.cs
+++ b/src/Greenshot.Base/Core/SimpleServiceProvider.cs
@@ -12,8 +12,12 @@ namespace Greenshot.Base.Core
     {
         private readonly Dictionary<Type, IList<object>> _services = new();
 
+        /// <summary>
+        /// Gets the current instance of the service locator.
+        /// </summary>
         public static IServiceLocator Current { get; } = new SimpleServiceProvider();
 
+        /// <inheritdoc/>
         public IReadOnlyList<TService> GetAllInstances<TService>()
         {
             var typeOfService = typeof(TService);
@@ -25,11 +29,13 @@ namespace Greenshot.Base.Core
             return results.Cast<TService>().ToArray();
         }
 
+        /// <inheritdoc/>
         public TService GetInstance<TService>()
         {
             return GetAllInstances<TService>().SingleOrDefault();
         }
 
+        /// <inheritdoc/>
         public void AddService<TService>(IEnumerable<TService> services)
         {
             var serviceType = typeof(TService);
@@ -50,9 +56,40 @@ namespace Greenshot.Base.Core
             }
         }
 
+        /// <inheritdoc/>
         public void AddService<TService>(params TService[] services)
         {
             AddService(services.AsEnumerable());
+        }
+
+        /// <inheritdoc/>
+        public void RemoveService<TService>(IEnumerable<TService> services)
+        {
+            var serviceType = typeof(TService);
+            if (!_services.TryGetValue(serviceType, out var currentServices))
+            {
+                return;
+            }
+
+            foreach (var service in services)
+            {
+                if (service == null)
+                {
+                    continue;
+                }
+                currentServices.Remove(service);
+            }
+
+            if (currentServices.Count == 0)
+            {
+                _services.Remove(serviceType);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void RemoveService<TService>(params TService[] services)
+        {
+            RemoveService(services.AsEnumerable());
         }
     }
 }

--- a/src/Greenshot.Base/Interfaces/IServiceLocator.cs
+++ b/src/Greenshot.Base/Interfaces/IServiceLocator.cs
@@ -54,5 +54,19 @@ namespace Greenshot.Base.Interfaces
         /// <typeparam name="TService">Type of the service</typeparam>
         /// <param name="services">IEnumerable{TService} with services to add</param>
         void AddService<TService>(IEnumerable<TService> services);
+
+        /// <summary>
+        /// Remove one or more services from the registry
+        /// </summary>
+        /// <typeparam name="TService">Type of the service</typeparam>
+        /// <param name="services">One or more services which need to be removed</param>
+        void RemoveService<TService>(params TService[] services);
+
+        /// <summary>
+        /// Remove multiple services from the registry
+        /// </summary>
+        /// <typeparam name="TService">Type of the service</typeparam>
+        /// <param name="services">IEnumerable{TService} with services to remove</param>
+        void RemoveService<TService>(IEnumerable<TService> services);
     }
 }


### PR DESCRIPTION
The function is not currently used. 
This allows us to use the `SimpleServiceProvider` later in a test framework.