### PR TITLE
Fix typo in About dialogue box

### DIFF
--- a/src/Greenshot/Forms/AboutForm.cs
+++ b/src/Greenshot/Forms/AboutForm.cs
@@ -153,7 +153,7 @@ namespace Greenshot.Forms
             _bitmap = ImageHelper.CreateEmpty(90, 90, PixelFormat.Format24bppRgb, BackColor, 96, 96);
             pictureBox1.Image = _bitmap;
 
-            lblTitle.Text = $@"Greenshot {EnvironmentInfo.GetGreenshotVersion()} {(IniConfig.IsPortable ? " Portable" : "")} ({OsInfo.Bits}) bit)";
+            lblTitle.Text = $@"Greenshot {EnvironmentInfo.GetGreenshotVersion()} {(IniConfig.IsPortable ? " Portable" : "")} ({OsInfo.Bits} bit)";
 
             // Number of frames the pixel animation takes
             int frames = FramesForMillis(2000);


### PR DESCRIPTION
The About box contains a typo - the closing bracket shouldn't exist!

<img width="532" height="325" alt="image" src="https://github.com/user-attachments/assets/6d69cf1d-de4e-463d-bee0-85ac8e03c36a" />
