### PR TITLE
Fix: Define plugin name for exclusion in INI

### DIFF
--- a/src/Greenshot.Base/Interfaces/Plugin/AssemblyPluginIdentifierAttribute.cs
+++ b/src/Greenshot.Base/Interfaces/Plugin/AssemblyPluginIdentifierAttribute.cs
@@ -1,0 +1,46 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+
+namespace Greenshot.Base.Interfaces.Plugin
+{
+    /// <summary>
+    /// Attribute to specify a custom plugin identifier at assembly level
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class AssemblyPluginIdentifierAttribute : Attribute
+    {
+        /// <summary>
+        /// The identifier used for the plugin in configuration
+        /// </summary>
+        public string Identifier { get; }
+
+        /// <summary>
+        /// Constructor for the plugin identifier attribute
+        /// </summary>
+        /// <param name="identifier">The identifier for the plugin in configuration</param>
+        public AssemblyPluginIdentifierAttribute(string identifier)
+        {
+            Identifier = identifier;
+        }
+    }
+}

--- a/src/Greenshot.Plugin.Confluence/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Confluence/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using Greenshot.Base.Interfaces.Plugin;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyDescription("A plugin to upload images to Box")]
-[assembly: AssemblyPluginIdentifier("Box Plugin")]
+[assembly: AssemblyDescription("A plugin to upload images to Confluence")]
+[assembly: AssemblyPluginIdentifier("Confluence Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Dropbox/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Dropbox/Properties/AssemblyInfo.cs
@@ -21,11 +21,13 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to Dropbox")]
+[assembly: AssemblyPluginIdentifier("Dropbox Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.ExternalCommand/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Greenshot - a free and open source screenshot tool
- * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom, Francis Noel
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom, Francis Noel
  * 
  * For more information see: https://getgreenshot.org/
  * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
@@ -26,8 +26,8 @@ using Greenshot.Base.Interfaces.Plugin;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyDescription("A plugin to upload images to Box")]
-[assembly: AssemblyPluginIdentifier("Box Plugin")]
+[assembly: AssemblyDescription("A plugin to send screenshots to other applications")]
+[assembly: AssemblyPluginIdentifier("External command Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Flickr/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Flickr/Properties/AssemblyInfo.cs
@@ -21,11 +21,13 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to Flickr")]
+[assembly: AssemblyPluginIdentifier("Flickr Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.GooglePhotos/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.GooglePhotos/Properties/AssemblyInfo.cs
@@ -21,11 +21,13 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to GooglePhotos")]
+[assembly: AssemblyPluginIdentifier("GooglePhotos Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.GooglePhotos/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.GooglePhotos/Properties/AssemblyInfo.cs
@@ -27,7 +27,10 @@ using Greenshot.Base.Interfaces.Plugin;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to GooglePhotos")]
-[assembly: AssemblyPluginIdentifier("GooglePhotos Plugin")]
+
+// Still using the old name 'Picasa-Web Plugin' as identifier for backwards compatibility
+// TODO: replace plugin identifier with "GooglePhotos Plugin" in the future
+[assembly: AssemblyPluginIdentifier("Picasa-Web Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Imgur/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Imgur/Properties/AssemblyInfo.cs
@@ -21,11 +21,13 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to Imgur")]
+[assembly: AssemblyPluginIdentifier("Imgur Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Jira/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Jira/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Greenshot - a free and open source screenshot tool
- * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom, Francis Noel
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom, Francis Noel
  * 
  * For more information see: https://getgreenshot.org/
  * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
@@ -26,8 +26,8 @@ using Greenshot.Base.Interfaces.Plugin;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyDescription("A plugin to upload images to Box")]
-[assembly: AssemblyPluginIdentifier("Box Plugin")]
+[assembly: AssemblyDescription("A plugin to upload images to Jira")]
+[assembly: AssemblyPluginIdentifier("Jira Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Office/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Office/Properties/AssemblyInfo.cs
@@ -21,11 +21,13 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to export images to Office applications")]
+[assembly: AssemblyPluginIdentifier("Office Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Photobucket/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Photobucket/Properties/AssemblyInfo.cs
@@ -21,12 +21,14 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plugin to upload images to Photobucket")]
+[assembly: AssemblyPluginIdentifier("Photobucket Plugin")]
 
 // This sets the default COM visibility of types in the assembly to invisible.
 // If you need to expose a type to COM, use [ComVisible(true)] on that type.

--- a/src/Greenshot.Plugin.Win10/Properties/AssemblyInfo.cs
+++ b/src/Greenshot.Plugin.Win10/Properties/AssemblyInfo.cs
@@ -1,10 +1,33 @@
-﻿using System.Reflection;
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Reflection;
 using System.Runtime.InteropServices;
+using Greenshot.Base.Interfaces.Plugin;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyDescription("A plug-in for Windows 10 only functionality")]
+[assembly: AssemblyPluginIdentifier("Win10 Plugin")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Greenshot/Helpers/PluginHelper.cs
+++ b/src/Greenshot/Helpers/PluginHelper.cs
@@ -224,13 +224,23 @@ namespace Greenshot.Helpers
                     var pluginEntryName = $"{assemblyName}.{assemblyName.Replace("Greenshot.Plugin.", string.Empty)}Plugin";
                     var pluginEntryType = assembly.GetType(pluginEntryName, false, true);
 
-                    // the sub namespace from plugin is used to exclude plugins
+                    // the sub namespace from plugin is used to include/exclude plugins
                     var excludeIdentifier = assemblyName.Replace("Greenshot.Plugin.", string.Empty);
 
-                    if (CoreConfig.ExcludePlugins != null && CoreConfig.ExcludePlugins.Contains(excludeIdentifier))
+                    if (CoreConfig.IncludePlugins is {} includePlugins
+                        && includePlugins.Count(p => !string.IsNullOrWhiteSpace(p)) > 0 // ignore empty entries i.e. a whitespace
+                        && !includePlugins.Contains(excludeIdentifier))
                     {
-                        Log.WarnFormat("Exclude list: {0}", string.Join(",", CoreConfig.ExcludePlugins));
-                        Log.WarnFormat("Skipping the excluded plugin {0} with version {1} from {2}", excludeIdentifier, assembly.GetName().Version, pluginFile);
+                        Log.WarnFormat("Include plugin list: {0}", string.Join(",", includePlugins));
+                        Log.WarnFormat("Skipping the not included plugin '{0}' with version {1} from {2}", excludeIdentifier, assembly.GetName().Version, pluginFile);
+                        continue;
+                    }
+
+                    if (CoreConfig.ExcludePlugins is { } excludePlugins
+                        && excludePlugins.Contains(excludeIdentifier))
+                    {
+                        Log.WarnFormat("Exclude plugin list: {0}", string.Join(",", excludePlugins));
+                        Log.WarnFormat("Skipping the excluded plugin '{0}' with version {1} from {2}", excludeIdentifier, assembly.GetName().Version, pluginFile);
                         continue;
                     }
 

--- a/src/Greenshot/Helpers/PluginHelper.cs
+++ b/src/Greenshot/Helpers/PluginHelper.cs
@@ -224,10 +224,13 @@ namespace Greenshot.Helpers
                     var pluginEntryName = $"{assemblyName}.{assemblyName.Replace("Greenshot.Plugin.", string.Empty)}Plugin";
                     var pluginEntryType = assembly.GetType(pluginEntryName, false, true);
 
-                    if (CoreConfig.ExcludePlugins != null && CoreConfig.ExcludePlugins.Contains(pluginEntryName))
+                    // the sub namespace from plugin is used to exclude plugins
+                    var excludeIdentifier = assemblyName.Replace("Greenshot.Plugin.", string.Empty);
+
+                    if (CoreConfig.ExcludePlugins != null && CoreConfig.ExcludePlugins.Contains(excludeIdentifier))
                     {
                         Log.WarnFormat("Exclude list: {0}", string.Join(",", CoreConfig.ExcludePlugins));
-                        Log.WarnFormat("Skipping the excluded plugin {0} with version {1} from {2}", pluginEntryName, assembly.GetName().Version, pluginFile);
+                        Log.WarnFormat("Skipping the excluded plugin {0} with version {1} from {2}", excludeIdentifier, assembly.GetName().Version, pluginFile);
                         continue;
                     }
 


### PR DESCRIPTION
This fixes #642.

The list of plugin names, as described in the [FAQ](https://getgreenshot.org/faq/how-remove-plugins-or-destinations-from-greenshot/), is no longer available.

I have defined a new way that extracts the name from the plugin's sub-namespace.
This is the new current list:
```
"Box"
"Confluence"
"Dropbox"
"ExternalCommand"
"Flickr"
"GooglePhotos"
"Imgur"
"Jira"
"Office"
"Photobucket"
"Win10"
```
I intentionally omitted the suffix `“ Plugin”` as it was previously included.