### PR TITLE
Fix update interval check on app start

### DIFF
--- a/src/Greenshot/Helpers/UpdateService.cs
+++ b/src/Greenshot/Helpers/UpdateService.cs
@@ -111,9 +111,14 @@ namespace Greenshot.Helpers
                 {
                     var interval = intervalFactory();
                     var task = reoccurringTask;
+
                     // If the check is disabled, handle that here
-                    if (TimeSpan.Zero == interval)
+                    var checkIsDisabled = TimeSpan.Zero == interval;
+                    var nextCheckIsInTheFuture = CoreConfig.LastUpdateCheck.Add(interval) > DateTime.Now;
+
+                    if (checkIsDisabled || nextCheckIsInTheFuture)
                     {
+                        // Just wait for 10 minutes, maybe the configuration will change
                         interval = TimeSpan.FromMinutes(10);
                         task = c => Task.FromResult(true);
                     }
@@ -158,6 +163,7 @@ namespace Greenshot.Helpers
             }
 
             CoreConfig.LastUpdateCheck = DateTime.Now;
+            IniConfig.Save();
 
             ProcessFeed(updateFeed);
 


### PR DESCRIPTION
If the `UpdateCheckInterval` setting is set to more than 0 days, Greenshot ignores this value each time it is launched. It checks for new versions every start.
As long as Greenshot is running, the next check would then be correct after the interval.

I have added a calculation that determines the next possible check date. If this is in the future, no check is performed.