### PR TITLE
[Feature] Close all open editors.

### DIFF
--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -450,6 +450,10 @@ namespace Greenshot.Editor.Forms
         {
             ClearItems(fileStripMenuItem.DropDownItems);
 
+            // check if CTRL is pressed and toggle CloseMenu
+            bool ctrlActive = (ModifierKeys & Keys.Control) == Keys.Control;
+            ToggleCloseMenuItemAction(ctrlActive);
+
             // Add the destinations
             foreach (IDestination destination in DestinationHelper.GetAllDestinations())
             {
@@ -474,6 +478,64 @@ namespace Greenshot.Editor.Forms
             // add the elements after the destinations
             fileStripMenuItem.DropDownItems.Add(toolStripSeparator9);
             fileStripMenuItem.DropDownItems.Add(closeToolStripMenuItem);
+
+            // register events to handle CTRL in DropDown
+            var dropDown = fileStripMenuItem.DropDown;
+
+            // remove event handler if already exists
+            dropDown.PreviewKeyDown -= FileMenuDropDown_PreviewKeyDown;
+            dropDown.KeyUp -= FileMenuDropDown_KeyUp;
+
+            // add event handler
+            dropDown.PreviewKeyDown += FileMenuDropDown_PreviewKeyDown;
+            dropDown.KeyUp += FileMenuDropDown_KeyUp;
+
+        }
+
+        /// <summary>
+        /// calls <see cref="ToggleCloseMenuItemAction"/> if CRTL is pressed
+        /// </summary>
+        private void FileMenuDropDown_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.Control)
+            {
+                ToggleCloseMenuItemAction(useCloseAllAction: true);
+            }
+        }
+
+        /// <summary>
+        /// calls <see cref="ToggleCloseMenuItemAction"/> if CRTL is released
+        /// </summary>
+        private void FileMenuDropDown_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (!e.Control)
+            {
+                ToggleCloseMenuItemAction(useCloseAllAction: false);
+            }
+        }
+
+        /// <summary>
+        /// toggle closing action. "close current editor" -- "close all open editors"
+        /// </summary>
+        /// <param name="useCloseAllAction">if true the menu action is "close all open editors" </param>
+        private void ToggleCloseMenuItemAction(bool useCloseAllAction)
+        {
+            if (useCloseAllAction)
+            {
+                closeToolStripMenuItem.LanguageKey = "editor_close_all";
+                closeToolStripMenuItem.ShortcutKeys = Keys.None;
+                closeToolStripMenuItem.Click -= CloseToolStripMenuItemClick;
+                closeToolStripMenuItem.Click += CloseAllToolStripMenuItemClick;
+            }
+            else
+            {
+                closeToolStripMenuItem.LanguageKey = "editor_close";
+                closeToolStripMenuItem.ShortcutKeys = Keys.Alt | Keys.F4;
+                closeToolStripMenuItem.Click -= CloseAllToolStripMenuItemClick;
+                closeToolStripMenuItem.Click += CloseToolStripMenuItemClick;
+            }
+
+            ApplyLanguage(closeToolStripMenuItem);
         }
 
         private delegate void SurfaceMessageReceivedThreadSafeDelegate(object sender, SurfaceMessageEventArgs eventArgs);
@@ -668,7 +730,30 @@ namespace Greenshot.Editor.Forms
 
         private void CloseToolStripMenuItemClick(object sender, EventArgs e)
         {
-            Close();
+            CloseEditor(closeAllOpenEditors: false);
+        }
+
+        private void CloseAllToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            CloseEditor(closeAllOpenEditors: true);
+        }
+
+        /// <summary>
+        /// Closes the current editor or all open editors in <see cref="Editors"/>.
+        /// </summary>
+        /// <param name="closeAllOpenEditors"></param>
+        private void CloseEditor(bool closeAllOpenEditors)
+        {
+            if (closeAllOpenEditors)
+            {
+                // we have to copy the list because closing the editor will remove it from the list
+                List<ImageEditorForm> closinglist = Editors.OfType<ImageEditorForm>().ToList();
+                closinglist.ForEach(e => e.Close());
+            }
+            else
+            {
+                Close();
+            }
         }
 
         private void BtnEllipseClick(object sender, EventArgs e)

--- a/src/Greenshot/Languages/language-cs-CZ.xml
+++ b/src/Greenshot/Languages/language-cs-CZ.xml
@@ -86,6 +86,7 @@ Také bychom velmi ocenili, kdybyste zkontrolovali, zda tato chyba již není ev
 		<resource name="editor_cancel">Zrušit</resource>
 		<resource name="editor_clipboardfailed">Chyba při přístupu do schránky. Zkuste to prosím znovu.</resource>
 		<resource name="editor_close">Zavřít</resource>
+		<resource name="editor_close_all">Zavřít vše</resource>
 		<resource name="editor_close_on_save">Chcete uložit snímek?</resource>
 		<resource name="editor_close_on_save_title">Uložit snímek?</resource>
 		<resource name="editor_confirm">Potvrdit</resource>

--- a/src/Greenshot/Languages/language-da-DK.xml
+++ b/src/Greenshot/Languages/language-da-DK.xml
@@ -240,6 +240,9 @@ Detaljer om GNU General Public License:
 	<resource name="editor_close">
 		Luk
 	</resource>
+	<resource name="editor_close_all">
+		Luk alle
+	</resource>
 	<resource name="warning">
 		Advarsel
 	</resource>

--- a/src/Greenshot/Languages/language-de-DE.xml
+++ b/src/Greenshot/Languages/language-de-DE.xml
@@ -86,6 +86,7 @@ schnell zu finden. Vielen Dank :)</resource>
 		<resource name="editor_cancel">Abbrechen</resource>
 		<resource name="editor_clipboardfailed">Fehler beim Zugriff auf die Zwischenablage. Bitte wiederholen Sie den Vorgang.</resource>
 		<resource name="editor_close">Schließen</resource>
+		<resource name="editor_close_all">Alles schließen</resource>
 		<resource name="editor_close_on_save">Möchten Sie den Screenshot speichern?</resource>
 		<resource name="editor_close_on_save_title">Bild speichern?</resource>
 		<resource name="editor_confirm">Bestätigen</resource>

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -87,6 +87,7 @@ Also, we would highly appreciate if you checked whether a tracker item already e
 		<resource name="editor_cancel">Cancel</resource>
 		<resource name="editor_clipboardfailed">Error while accessing the clipboard. Please try again.</resource>
 		<resource name="editor_close">Close</resource>
+		<resource name="editor_close_all">Close all</resource>
 		<resource name="editor_close_on_save">Do you want to save the screenshot?</resource>
 		<resource name="editor_close_on_save_title">Save image?</resource>
 		<resource name="editor_confirm">Confirm</resource>

--- a/src/Greenshot/Languages/language-es-ES.xml
+++ b/src/Greenshot/Languages/language-es-ES.xml
@@ -73,6 +73,7 @@ Antes de crear un nuevo informe de error, te agradeceríamos que comprobaras que
 		<resource name="editor_cancel">Cancelar</resource>
 		<resource name="editor_clipboardfailed">Error accdeiendo al portapapeles. Por favor, inténtalo otra vez.</resource>
 		<resource name="editor_close">Cerrar</resource>
+		<resource name="editor_close_all">Cerrar todo</resource>
 		<resource name="editor_close_on_save">¿Guardar la captura?</resource>
 		<resource name="editor_close_on_save_title">¿Guardar imagen?</resource>
 		<resource name="editor_confirm">Confirmar</resource>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -85,6 +85,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_cancel">Annuler</resource>
 		<resource name="editor_clipboardfailed">Une erreur s'est produite lors de l'accès au presse-papier. Veuillez réessayer.</resource>
 		<resource name="editor_close">Fermer</resource>
+		<resource name="editor_close_all">Fermer tout</resource>
 		<resource name="editor_close_on_save">Voulez-vous enregistrer la capture d'écran ?</resource>
 		<resource name="editor_close_on_save_title">Enregistrer l'image ?</resource>
 		<resource name="editor_confirm">Confirmer</resource>

--- a/src/Greenshot/Languages/language-it-IT.xml
+++ b/src/Greenshot/Languages/language-it-IT.xml
@@ -91,6 +91,7 @@ Controlla i permessi di accesso per '{0}'.</resource>
         <resource name="editor_cancel">Annulla</resource>
         <resource name="editor_clipboardfailed">Errore durante l'accesso agli Appunti. Ritenta nuovamente.</resource>
         <resource name="editor_close">Chiudi</resource>
+        <resource name="editor_close_all">Chiudi tutto</resource>
         <resource name="editor_close_on_save">Vuoi salvare l'immagine?</resource>
         <resource name="editor_close_on_save_title">Vuoi salvare l'immagine?</resource>
         <resource name="editor_confirm">Conferma</resource>

--- a/src/Greenshot/Languages/language-nl-NL.xml
+++ b/src/Greenshot/Languages/language-nl-NL.xml
@@ -86,6 +86,7 @@ Controleer ook even of dit probleem mogelijk al gemeld is! Gebruik de zoekfuncti
 		<resource name="editor_cancel">Afbreken</resource>
 		<resource name="editor_clipboardfailed">Fout bij de toegang tot het klembord. Probeer het opnieuw.</resource>
 		<resource name="editor_close">Sluiten</resource>
+		<resource name="editor_close_all">Alles sluiten</resource>
 		<resource name="editor_close_on_save">Wilt u de schermopname opslaan?</resource>
 		<resource name="editor_close_on_save_title">Afbeelding opslaan?</resource>
 		<resource name="editor_confirm">Bevestigen</resource>

--- a/src/Greenshot/Languages/language-nn-NO.xml
+++ b/src/Greenshot/Languages/language-nn-NO.xml
@@ -73,6 +73,7 @@ Me sett òg pris på om du ved hjelp av søkefunksjonen på sida kan sjekke om d
 		<resource name="editor_cancel">Avbryt</resource>
 		<resource name="editor_clipboardfailed">Kunne ikkje bruke utklyppstavla! Ver venleg og prøv att.</resource>
 		<resource name="editor_close">Lukk</resource>
+		<resource name="editor_close_all">Lukk alle</resource>
 		<resource name="editor_close_on_save">Vil du lagre skjermbildet?</resource>
 		<resource name="editor_close_on_save_title">Vil du lagre bildet?</resource>
 		<resource name="editor_confirm">Stadfest</resource>

--- a/src/Greenshot/Languages/language-pl-PL.xml
+++ b/src/Greenshot/Languages/language-pl-PL.xml
@@ -86,6 +86,7 @@ Będziemy wdzięczni, jeśli najpierw sprawdzisz, czy takie zdarzenie nie zosta�
 		<resource name="editor_cancel">Anuluj</resource>
 		<resource name="editor_clipboardfailed">Błąd przy próbie dostępu do schowka. Spróbuj ponownie.</resource>
 		<resource name="editor_close">Zamknij</resource>
+		<resource name="editor_close_all">Zamknij wszystkie</resource>
 		<resource name="editor_close_on_save">Czy chcesz zapisać zrzut ekranu?</resource>
 		<resource name="editor_close_on_save_title">Zapisać obraz?</resource>
 		<resource name="editor_confirm">Zatwierdź</resource>

--- a/src/Greenshot/Languages/language-pt-BR.xml
+++ b/src/Greenshot/Languages/language-pt-BR.xml
@@ -82,6 +82,7 @@
 		<resource name="editor_cancel">Cancelar</resource>
 		<resource name="editor_clipboardfailed">Erro ao accesar a área de transferência. Por favor tente novamente.</resource>
 		<resource name="editor_close">Fechar</resource>
+		<resource name="editor_close_all">Fechar tudo</resource>
 		<resource name="editor_close_on_save">Deseja salvar a imagem capturada?</resource>
 		<resource name="editor_close_on_save_title">Salvar imagem?</resource>
 		<resource name="editor_confirm">Confirmar</resource>

--- a/src/Greenshot/Languages/language-pt-PT.xml
+++ b/src/Greenshot/Languages/language-pt-PT.xml
@@ -85,6 +85,7 @@ Também apreciaremos muito se puder verificar se não existe já um relatório d
 		<resource name="editor_cancel">Cancelar</resource>
 		<resource name="editor_clipboardfailed">Erro ao aceder à área de transferência. Por favor tente novamente.</resource>
 		<resource name="editor_close">Fechar</resource>
+		<resource name="editor_close_all">Fechar tudo</resource>
 		<resource name="editor_close_on_save">Deseja guardar a imagem capturada?</resource>
 		<resource name="editor_close_on_save_title">Guardar imagem?</resource>
 		<resource name="editor_confirm">Confirmar</resource>

--- a/src/Greenshot/Languages/language-ru-RU.xml
+++ b/src/Greenshot/Languages/language-ru-RU.xml
@@ -86,6 +86,7 @@ Greenshot поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ.�
 		<resource name="editor_cancel">Отмена</resource>
 		<resource name="editor_clipboardfailed">Ошибка при попытке доступа в буфер обмена. Пожалуйста, попробуйте снова.</resource>
 		<resource name="editor_close">Закрыть</resource>
+		<resource name="editor_close_all">Закрыть все</resource>
 		<resource name="editor_close_on_save">Сохранить снимок экрана?</resource>
 		<resource name="editor_close_on_save_title">Сохранить изображение?</resource>
 		<resource name="editor_confirm">Подтвердить</resource>

--- a/src/Greenshot/Languages/language-sv-SE.xml
+++ b/src/Greenshot/Languages/language-sv-SE.xml
@@ -86,6 +86,7 @@ Innan du skickar uppskattar vi verkligen om du kontrollerar om felet redan blivi
 		<resource name="editor_cancel">Avbryt</resource>
 		<resource name="editor_clipboardfailed">Ett fel uppstod vid åtkomst av urklipp. Försök igen.</resource>
 		<resource name="editor_close">Stäng</resource>
+		<resource name="editor_close_all">Stäng alla</resource>
 		<resource name="editor_close_on_save">Vill du spara skärmdumpen?</resource>
 		<resource name="editor_close_on_save_title">Spara bild?</resource>
 		<resource name="editor_confirm">Godkänn</resource>


### PR DESCRIPTION
I added a feature to close all open editors at once.
_This references [FEATURE-333](https://greenshot.atlassian.net/browse/FEATURE-333) and [FEATURE-880](https://greenshot.atlassian.net/browse/FEATURE-880)_

While pressing `CRTL` the closing action in file menu is changing to `Close all`.

![Close_all_2](https://github.com/user-attachments/assets/c5c8b34e-d346-4d82-981f-3b1c6966d8f4)

Every `ImageEditorForm` has a static list with all created editors.  So the close all action calls `close()` on every editor in this list.
The request to save on every editor may still occur if necessary.

I added some translations also. 