### PR TITLE
[Fix] Delay in context menu

### DIFF
--- a/src/Greenshot.Base/Core/AbstractDestination.cs
+++ b/src/Greenshot.Base/Core/AbstractDestination.cs
@@ -22,7 +22,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Threading;
 using System.Windows.Forms;
 using Dapplo.Windows.Common.Extensions;
 using Dapplo.Windows.Common.Structs;
@@ -184,6 +183,8 @@ namespace Greenshot.Base.Core
                 TopLevel = true
             };
 
+            menu.SetupAutoDispose();
+
             menu.Opening += (sender, args) =>
             {
                 // find the DPI settings for the screen where this is going to land
@@ -332,21 +333,6 @@ namespace Greenshot.Base.Core
             User32Api.SetForegroundWindow(SimpleServiceProvider.Current.GetInstance<NotifyIcon>().ContextMenuStrip.Handle);
             menu.Show(location);
             menu.Focus();
-
-            // Wait for the menu to close, so we can dispose it.
-            while (true)
-            {
-                if (menu.Visible)
-                {
-                    Application.DoEvents();
-                    Thread.Sleep(100);
-                }
-                else
-                {
-                    menu.Dispose();
-                    break;
-                }
-            }
         }
 
         /// <summary>

--- a/src/Greenshot.Base/Core/MenuHelper.cs
+++ b/src/Greenshot.Base/Core/MenuHelper.cs
@@ -1,0 +1,58 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Windows.Forms;
+using log4net;
+
+namespace Greenshot.Base.Core
+{
+    /// <summary>
+    /// Helper class for menu related functionality
+    /// </summary>
+    public static class MenuHelper
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(MenuHelper));
+
+        /// <summary>
+        /// Sets up automatic disposal for ContextMenuStrip when closed.
+        /// This prevents memory leaks by ensuring the menu is properly disposed
+        /// when it's no longer needed. Uses delayed disposal to avoid ObjectDisposedException.
+        /// </summary>
+        /// <param name="menu">The ContextMenuStrip to setup auto-disposal for</param>
+        public static void SetupAutoDispose(this ContextMenuStrip menu)
+        {
+            menu.Closed += (sender, e) =>
+            {
+                Log.Debug("ContextMenuStrip closed, scheduling delayed disposal");
+
+                // delayed disposal -- waiting for ClickHandler beeing finished
+                menu.BeginInvoke(new System.Action(() =>
+                {
+                    if (!menu.IsDisposed)
+                    {
+                        Log.Debug("Disposing ContextMenuStrip");
+                        menu.Dispose();
+                    }
+                }));
+            };
+        }
+    }
+}

--- a/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
@@ -728,22 +728,10 @@ namespace Greenshot.Editor.Drawing
             if (!hasMenu) return;
             
             ContextMenuStrip menu = new ContextMenuStrip();
+            menu.SetupAutoDispose();
             AddContextMenuItems(menu, surface, mouseEventArgs);
             if (menu.Items.Count <= 0) return;
             menu.Show(surface, surface.ToSurfaceCoordinates(mouseEventArgs.Location));
-            while (true)
-            {
-                if (menu.Visible)
-                {
-                    Application.DoEvents();
-                    Thread.Sleep(100);
-                }
-                else
-                {
-                    menu.Dispose();
-                    break;
-                }
-            }
         }
 
         private bool _disposedValue; // To detect redundant calls


### PR DESCRIPTION
In some context menus, there was a strange endless loop that was supposed to ensure that the menu was disposed correctly.

I have changed this behavior and now use the Closed-Event.
In addition, `dispose()` is scheduled in the UI thread to wait for the ClickHandler to complete.

We had the same issue in the destination picker menu and in the editor context menu. I correct both.
This fixes #666