### PR TITLE
[Feature]  Define output image format for external command

### DIFF
--- a/src/Greenshot.Base/Controls/EnumComboBox.cs
+++ b/src/Greenshot.Base/Controls/EnumComboBox.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Windows.Forms;
+using Greenshot.Base.Core;
+
+namespace Greenshot.Base.Controls
+{
+    public class EnumComboBox : ComboBox
+    {
+        private Type _enumType;
+        private Enum _selectedEnum;
+
+        public EnumComboBox()
+        {
+            SelectedIndexChanged += delegate { StoreSelectedEnum(); };
+        }
+
+        public void SetValue(Enum currentValue)
+        {
+            if (currentValue != null)
+            {
+                _selectedEnum = currentValue;
+                SelectedItem = Language.Translate(currentValue);
+            }
+        }
+
+        /// <summary>
+        /// This is a method to popululate the ComboBox
+        /// with the items from the enumeration
+        /// </summary>
+        /// <param name="enumType">TEnum to populate with</param>
+        public void Populate(Type enumType)
+        {
+            // Store the enum-type, so we can work with it
+            _enumType = enumType;
+
+            var availableValues = Enum.GetValues(enumType);
+            Items.Clear();
+            foreach (var enumValue in availableValues)
+            {
+                Items.Add(Language.Translate((Enum) enumValue));
+            }
+        }
+
+        /// <summary>
+        /// Store the selected value internally
+        /// </summary>
+        private void StoreSelectedEnum()
+        {
+            string enumTypeName = _enumType.Name;
+            string selectedValue = SelectedItem as string;
+            var availableValues = Enum.GetValues(_enumType);
+            object returnValue = null;
+
+            try
+            {
+                returnValue = Enum.Parse(_enumType, selectedValue);
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+
+            foreach (Enum enumValue in availableValues)
+            {
+                string enumKey = enumTypeName + "." + enumValue;
+                if (Language.HasKey(enumKey))
+                {
+                    string translation = Language.GetString(enumTypeName + "." + enumValue);
+                    if (translation.Equals(selectedValue))
+                    {
+                        returnValue = enumValue;
+                    }
+                }
+            }
+
+            _selectedEnum = (Enum) returnValue;
+        }
+
+        /// <summary>
+        /// Get the selected enum value from the combobox, uses generics
+        /// </summary>
+        /// <returns>The enum value of the combobox</returns>
+        public Enum GetSelectedEnum()
+        {
+            return _selectedEnum;
+        }
+    }
+}

--- a/src/Greenshot.Base/Controls/GreenshotComboBox.cs
+++ b/src/Greenshot.Base/Controls/GreenshotComboBox.cs
@@ -26,11 +26,8 @@ using Greenshot.Base.Core;
 
 namespace Greenshot.Base.Controls
 {
-    public class GreenshotComboBox : ComboBox, IGreenshotConfigBindable
+    public class GreenshotComboBox : EnumComboBox, IGreenshotConfigBindable
     {
-        private Type _enumType;
-        private Enum _selectedEnum;
-
         [Category("Greenshot"), DefaultValue("Core"), Description("Specifies the Ini-Section to map this control with.")]
         public string SectionName { get; set; } = "Core";
 
@@ -39,78 +36,7 @@ namespace Greenshot.Base.Controls
 
         public GreenshotComboBox()
         {
-            SelectedIndexChanged += delegate { StoreSelectedEnum(); };
         }
 
-        public void SetValue(Enum currentValue)
-        {
-            if (currentValue != null)
-            {
-                _selectedEnum = currentValue;
-                SelectedItem = Language.Translate(currentValue);
-            }
-        }
-
-        /// <summary>
-        /// This is a method to popululate the ComboBox
-        /// with the items from the enumeration
-        /// </summary>
-        /// <param name="enumType">TEnum to populate with</param>
-        public void Populate(Type enumType)
-        {
-            // Store the enum-type, so we can work with it
-            _enumType = enumType;
-
-            var availableValues = Enum.GetValues(enumType);
-            Items.Clear();
-            foreach (var enumValue in availableValues)
-            {
-                Items.Add(Language.Translate((Enum) enumValue));
-            }
-        }
-
-        /// <summary>
-        /// Store the selected value internally
-        /// </summary>
-        private void StoreSelectedEnum()
-        {
-            string enumTypeName = _enumType.Name;
-            string selectedValue = SelectedItem as string;
-            var availableValues = Enum.GetValues(_enumType);
-            object returnValue = null;
-
-            try
-            {
-                returnValue = Enum.Parse(_enumType, selectedValue);
-            }
-            catch (Exception)
-            {
-                // Ignore
-            }
-
-            foreach (Enum enumValue in availableValues)
-            {
-                string enumKey = enumTypeName + "." + enumValue;
-                if (Language.HasKey(enumKey))
-                {
-                    string translation = Language.GetString(enumTypeName + "." + enumValue);
-                    if (translation.Equals(selectedValue))
-                    {
-                        returnValue = enumValue;
-                    }
-                }
-            }
-
-            _selectedEnum = (Enum) returnValue;
-        }
-
-        /// <summary>
-        /// Get the selected enum value from the combobox, uses generics
-        /// </summary>
-        /// <returns>The enum value of the combobox</returns>
-        public Enum GetSelectedEnum()
-        {
-            return _selectedEnum;
-        }
     }
 }

--- a/src/Greenshot.Plugin.ExternalCommand/ExternalCommandConfiguration.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/ExternalCommandConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Greenshot - a free and open source screenshot tool
- * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
  * 
  * For more information see: https://getgreenshot.org/
  * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Greenshot.Base.Core;
+using Greenshot.Base.Core.Enums;
 using Greenshot.Base.IniFile;
 
 namespace Greenshot.Plugin.ExternalCommand
@@ -68,6 +69,9 @@ namespace Greenshot.Plugin.ExternalCommand
 
         [IniProperty("Argument", Description = "The arguments for the output command.")]
         public Dictionary<string, string> Argument { get; set; }
+
+        [IniProperty("OutputFormat", Description = "The output file format for the output command.")]
+        public Dictionary<string, OutputFormat> OutputFormat { get; set; }
 
         [IniProperty("RunInbackground", Description = "Should the command be started in the background.")]
         public Dictionary<string, bool> RunInbackground { get; set; }
@@ -166,6 +170,7 @@ namespace Greenshot.Plugin.ExternalCommand
                 nameof(Commandline) => new Dictionary<string, string>(),
                 nameof(Argument) => new Dictionary<string, string>(),
                 nameof(RunInbackground) => new Dictionary<string, bool>(),
+                nameof(OutputFormat) => new Dictionary<string, OutputFormat>(),
                 _ => null
             };
     }

--- a/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
@@ -25,6 +25,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Windows.Forms;
 using Greenshot.Base.Core;
+using Greenshot.Base.Core.Enums;
 using Greenshot.Base.IniFile;
 using Greenshot.Base.Interfaces;
 using Greenshot.Base.Interfaces.Plugin;
@@ -93,6 +94,11 @@ namespace Greenshot.Plugin.ExternalCommand
                 Log.WarnFormat("Found missing argument for {0}", command);
                 // Fix it
                 ExternalCommandConfig.Argument.Add(command, "{0}");
+            }
+
+            if (!ExternalCommandConfig.OutputFormat.ContainsKey(command))
+            {
+                ExternalCommandConfig.OutputFormat.Add(command, OutputFormat.png);
             }
 
             if (!ExternalCommandConfig.Commandline.ContainsKey(command))

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-cs-CZ.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-cs-CZ.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} je název vašeho snímku
     </resource>
+    <resource name="label_outputimageformat">Formát obrázku</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-de-DE.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-de-DE.xml
@@ -26,10 +26,11 @@
       Befehl
     </resource>
     <resource name="label_argument">
-      Arguments
+      Argumente
     </resource>
     <resource name="label_information">
       {0} ist der Dateiname des Screenshots
     </resource>
+    <resource name="label_outputimageformat">Bildformat</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-en-US.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-en-US.xml
@@ -28,6 +28,7 @@
     <resource name="label_argument">
       Arguments
     </resource>
+    <resource name="label_outputimageformat">Image format</resource>
     <resource name="label_information">
       {0} is the filename of your screenshot
     </resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-fr-FR.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-fr-FR.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} est le nom du fichier de votre capture d'écran
     </resource>
+    <resource name="label_outputimageformat">Format d'image</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-id-ID.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-id-ID.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">Perintah</resource>
 		<resource name="label_information">{0} adalah nama berkas dari tangkapan anda</resource>
 		<resource name="label_name">Nama</resource>
+		<resource name="label_outputimageformat">Format Gambar</resource>
 		<resource name="settings_delete">Hapus</resource>
 		<resource name="settings_detail_title">Konfigursi perintah</resource>
 		<resource name="settings_edit">Edit</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-it-IT.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-it-IT.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} è il noem file della schermata
     </resource>
+    <resource name="label_outputimageformat">Formato immagine</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ja-JP.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ja-JP.xml
@@ -11,5 +11,6 @@
 		<resource name="label_command">コマンド</resource>
 		<resource name="label_argument">引数</resource>
 		<resource name="label_information">{0} はスクリーンショットのファイルパスです</resource>
+		<resource name="label_outputimageformat">画像フォーマット</resource>
 	</resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-kab-DZ.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-kab-DZ.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} d isem n ufaylu n tuṭṭfa yinek n ugdil
     </resource>
+    <resource name="label_outputimageformat">Amasal n tugna</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ko-KR.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ko-KR.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0}은 이미지 파일명입니다
     </resource>
+    <resource name="label_outputimageformat">이미지 형식</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-lv-LV.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-lv-LV.xml
@@ -32,5 +32,6 @@
     <resource name="label_information">
       {0} – ekrānattēla vārds
     </resource>
+    <resource name="label_outputimageformat">Attēla veids</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-pl-PL.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-pl-PL.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">Komenda</resource>
 		<resource name="label_information">{0} oznacza nazwę pliku zrzutu ekranu</resource>
 		<resource name="label_name">Nazwa</resource>
+		<resource name="label_outputimageformat">Format obrazu</resource>
 		<resource name="settings_delete">Usuń</resource>
 		<resource name="settings_detail_title">Ustawienia komendy</resource>
 		<resource name="settings_edit">Edytuj</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-pt-PT.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-pt-PT.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} é o nome do ficheiro da sua captura
     </resource>
+    <resource name="label_outputimageformat">Formato de Imagem</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ru-RU.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-ru-RU.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">Команда</resource>
 		<resource name="label_information">{0} это имя файла вашего скриншота</resource>
 		<resource name="label_name">Имя</resource>
+		<resource name="label_outputimageformat">Формат изображения</resource>
 		<resource name="settings_delete">Удалить</resource>
 		<resource name="settings_detail_title">Настройка команды</resource>
 		<resource name="settings_edit">Изменить</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sk-SK.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sk-SK.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} = názov súboru kde je uložená snímka
     </resource>
+    <resource name="label_outputimageformat">Formát obrázku</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sr-RS.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sr-RS.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">Наредба:</resource>
 		<resource name="label_information">{0} је назив снимка екрана.</resource>
 		<resource name="label_name">Назив:</resource>
+		<resource name="label_outputimageformat">Формат слике</resource>
 		<resource name="settings_delete">Обриши</resource>
 		<resource name="settings_detail_title">Подешавање наредби</resource>
 		<resource name="settings_edit">Уреди</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sv-SE.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-sv-SE.xml
@@ -31,5 +31,6 @@
     <resource name="label_information">
       {0} är din skärmdumps filnamn
     </resource>
+    <resource name="label_outputimageformat">Bildformat</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-uk-UA.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-uk-UA.xml
@@ -11,5 +11,6 @@
     <resource name="label_command">Команда</resource>
     <resource name="label_argument">Аргументи</resource>
     <resource name="label_information">{0} — назва файла Вашого знімку</resource>
+    <resource name="label_outputimageformat">Формат зображення</resource>
   </resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-zh-CN.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-zh-CN.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">命令</resource>
 		<resource name="label_information">{0}为您的截图文件的名称</resource>
 		<resource name="label_name">名称</resource>
+		<resource name="label_outputimageformat">图像格式</resource>
 		<resource name="settings_delete">删除</resource>
 		<resource name="settings_detail_title">配置命令</resource>
 		<resource name="settings_edit">编辑</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-zh-TW.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-zh-TW.xml
@@ -6,6 +6,7 @@
 		<resource name="label_command">命令</resource>
 		<resource name="label_information">{0} 是螢幕擷圖的檔案名稱</resource>
 		<resource name="label_name">名稱</resource>
+		<resource name="label_outputimageformat">圖片格式</resource>
 		<resource name="settings_delete">刪除</resource>
 		<resource name="settings_detail_title">組態命令</resource>
 		<resource name="settings_edit">編輯</resource>

--- a/src/Greenshot.Plugin.ExternalCommand/SettingsFormDetail.Designer.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/SettingsFormDetail.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Greenshot - a free and open source screenshot tool
- * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom
+ * Copyright (C) 2007-2025 Thomas Braun, Jens Klingen, Robin Krom
  * 
  * For more information see: https://getgreenshot.org/
  * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
@@ -20,6 +20,7 @@
  */
 
 using Greenshot.Base.Controls;
+using Greenshot.Base.Core;
 
 namespace Greenshot.Plugin.ExternalCommand {
 	partial class SettingsFormDetail {
@@ -53,150 +54,181 @@ namespace Greenshot.Plugin.ExternalCommand {
 			this.buttonCancel = new GreenshotButton();
 			this.groupBox1 = new GreenshotGroupBox();
 			this.label4 = new GreenshotLabel();
-			this.buttonPathSelect = new System.Windows.Forms.Button();
+            this.buttonPathSelect = new System.Windows.Forms.Button();
 			this.label3 = new GreenshotLabel();
-			this.textBox_name = new System.Windows.Forms.TextBox();
+            this.textBox_name = new System.Windows.Forms.TextBox();
 			this.label2 = new GreenshotLabel();
-			this.textBox_arguments = new System.Windows.Forms.TextBox();
+            this.textBox_arguments = new System.Windows.Forms.TextBox();
 			this.label1 = new GreenshotLabel();
-			this.textBox_commandline = new System.Windows.Forms.TextBox();
-			this.groupBox1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// buttonOk
-			// 
-			this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.buttonOk.Enabled = false;
-			this.buttonOk.LanguageKey = "OK";
-			this.buttonOk.Location = new System.Drawing.Point(273, 140);
-			this.buttonOk.Name = "buttonOk";
-			this.buttonOk.Size = new System.Drawing.Size(75, 23);
-			this.buttonOk.TabIndex = 10;
-			this.buttonOk.UseVisualStyleBackColor = true;
-			this.buttonOk.Click += new System.EventHandler(this.ButtonOkClick);
-			// 
-			// buttonCancel
-			// 
-			this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.buttonCancel.LanguageKey = "CANCEL";
-			this.buttonCancel.Location = new System.Drawing.Point(9, 140);
-			this.buttonCancel.Name = "buttonCancel";
-			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-			this.buttonCancel.TabIndex = 11;
-			this.buttonCancel.UseVisualStyleBackColor = true;
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.label4);
-			this.groupBox1.Controls.Add(this.buttonPathSelect);
-			this.groupBox1.Controls.Add(this.label3);
-			this.groupBox1.Controls.Add(this.textBox_name);
-			this.groupBox1.Controls.Add(this.label2);
-			this.groupBox1.Controls.Add(this.textBox_arguments);
-			this.groupBox1.Controls.Add(this.label1);
-			this.groupBox1.Controls.Add(this.textBox_commandline);
-			this.groupBox1.LanguageKey = "settings_title";
-			this.groupBox1.Location = new System.Drawing.Point(10, 12);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(339, 122);
-			this.groupBox1.TabIndex = 28;
-			this.groupBox1.TabStop = false;
-			// 
-			// label4
-			// 
-			this.label4.LanguageKey = "externalcommand.label_information";
-			this.label4.Location = new System.Drawing.Point(68, 98);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(225, 21);
-			this.label4.TabIndex = 19;
-			// 
-			// buttonPathSelect
-			// 
-			this.buttonPathSelect.Location = new System.Drawing.Point(298, 47);
-			this.buttonPathSelect.Name = "buttonPathSelect";
-			this.buttonPathSelect.Size = new System.Drawing.Size(33, 23);
-			this.buttonPathSelect.TabIndex = 3;
-			this.buttonPathSelect.Text = "...";
-			this.buttonPathSelect.UseVisualStyleBackColor = true;
-			this.buttonPathSelect.Click += new System.EventHandler(this.Button3Click);
-			// 
-			// label3
-			// 
-			this.label3.LanguageKey = "externalcommand.label_name";
-			this.label3.Location = new System.Drawing.Point(6, 26);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(56, 17);
-			this.label3.TabIndex = 17;
-			// 
-			// textBox_name
-			// 
-			this.textBox_name.Location = new System.Drawing.Point(68, 23);
-			this.textBox_name.Name = "textBox_name";
-			this.textBox_name.Size = new System.Drawing.Size(225, 20);
-			this.textBox_name.TabIndex = 1;
-			this.textBox_name.TextChanged += new System.EventHandler(this.textBox_name_TextChanged);
-			// 
-			// label2
-			// 
-			this.label2.LanguageKey = "externalcommand.label_argument";
-			this.label2.Location = new System.Drawing.Point(6, 78);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(56, 17);
-			this.label2.TabIndex = 16;
-			// 
-			// textBox_arguments
-			// 
-			this.textBox_arguments.Location = new System.Drawing.Point(68, 75);
-			this.textBox_arguments.Name = "textBox_arguments";
-			this.textBox_arguments.Size = new System.Drawing.Size(225, 20);
-			this.textBox_arguments.TabIndex = 4;
+            this.textBox_commandline = new System.Windows.Forms.TextBox();
+            this.label5 = new GreenshotLabel();
+            this.comboBox_outputFormat = new EnumComboBox();
+            this.groupBox1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // buttonOk
+            // 
+            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOk.Enabled = false;
+            this.buttonOk.LanguageKey = "OK";
+            this.buttonOk.Location = new System.Drawing.Point(274, 169);
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.Size = new System.Drawing.Size(75, 23);
+            this.buttonOk.TabIndex = 10;
+            this.buttonOk.Text = "OK";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            this.buttonOk.Click += new System.EventHandler(this.ButtonOkClick);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.LanguageKey = "CANCEL";
+            this.buttonCancel.Location = new System.Drawing.Point(10, 169);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 11;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.buttonPathSelect);
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.textBox_name);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.textBox_arguments);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Controls.Add(this.textBox_commandline);
+            this.groupBox1.Controls.Add(this.label5);
+            this.groupBox1.Controls.Add(this.comboBox_outputFormat);
+            this.groupBox1.LanguageKey = "settings_title";
+            this.groupBox1.Location = new System.Drawing.Point(10, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(339, 151);
+            this.groupBox1.TabIndex = 28;
+            this.groupBox1.TabStop = false;
+            // 
+            // label4
+            // 
+            this.label4.LanguageKey = "externalcommand.label_information";
+            this.label4.Location = new System.Drawing.Point(95, 98);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(198, 21);
+            this.label4.TabIndex = 19;
+            this.label4.Text = "{0} is the filename of your screenshot";
+            // 
+            // buttonPathSelect
+            // 
+            this.buttonPathSelect.Location = new System.Drawing.Point(298, 47);
+            this.buttonPathSelect.Name = "buttonPathSelect";
+            this.buttonPathSelect.Size = new System.Drawing.Size(33, 23);
+            this.buttonPathSelect.TabIndex = 3;
+            this.buttonPathSelect.Text = "...";
+            this.buttonPathSelect.UseVisualStyleBackColor = true;
+            this.buttonPathSelect.Click += new System.EventHandler(this.Button3Click);
+            // 
+            // label3
+            // 
+            this.label3.LanguageKey = "externalcommand.label_name";
+            this.label3.Location = new System.Drawing.Point(6, 26);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(83, 17);
+            this.label3.TabIndex = 17;
+            this.label3.Text = "Name";
+            // 
+            // textBox_name
+            // 
+            this.textBox_name.Location = new System.Drawing.Point(95, 23);
+            this.textBox_name.Name = "textBox_name";
+            this.textBox_name.Size = new System.Drawing.Size(198, 20);
+            this.textBox_name.TabIndex = 1;
+            this.textBox_name.TextChanged += new System.EventHandler(this.textBox_name_TextChanged);
+            // 
+            // label2
+            // 
+            this.label2.LanguageKey = "externalcommand.label_argument";
+            this.label2.Location = new System.Drawing.Point(6, 78);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(83, 17);
+            this.label2.TabIndex = 16;
+            this.label2.Text = "Arguments";
+            // 
+            // textBox_arguments
+            // 
+            this.textBox_arguments.Location = new System.Drawing.Point(95, 75);
+            this.textBox_arguments.Name = "textBox_arguments";
+            this.textBox_arguments.Size = new System.Drawing.Size(198, 20);
+            this.textBox_arguments.TabIndex = 4;
             this.textBox_arguments.TextChanged += new System.EventHandler(this.textBox_arguments_TextChanged);
-			// 
-			// label1
-			// 
-			this.label1.LanguageKey = "externalcommand.label_command";
-			this.label1.Location = new System.Drawing.Point(6, 52);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(56, 17);
-			this.label1.TabIndex = 15;
-			// 
-			// textBox_commandline
-			// 
-			this.textBox_commandline.Location = new System.Drawing.Point(68, 49);
-			this.textBox_commandline.Name = "textBox_commandline";
-			this.textBox_commandline.Size = new System.Drawing.Size(225, 20);
-			this.textBox_commandline.TabIndex = 2;
-			this.textBox_commandline.TextChanged += new System.EventHandler(this.textBox_commandline_TextChanged);
-			// 
-			// SettingsFormDetail
-			// 
-			this.AcceptButton = this.buttonOk;
+            // 
+            // label1
+            // 
+            this.label1.LanguageKey = "externalcommand.label_command";
+            this.label1.Location = new System.Drawing.Point(6, 52);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(83, 17);
+            this.label1.TabIndex = 15;
+            this.label1.Text = "Command";
+            // 
+            // textBox_commandline
+            // 
+            this.textBox_commandline.Location = new System.Drawing.Point(95, 49);
+            this.textBox_commandline.Name = "textBox_commandline";
+            this.textBox_commandline.Size = new System.Drawing.Size(198, 20);
+            this.textBox_commandline.TabIndex = 2;
+            this.textBox_commandline.TextChanged += new System.EventHandler(this.textBox_commandline_TextChanged);
+            // 
+            // label5
+            // 
+            this.label5.LanguageKey = "externalcommand.label_outputimageformat";
+            this.label5.Location = new System.Drawing.Point(6, 126);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(83, 17);
+            this.label5.TabIndex = 18;
+            this.label5.Text = "Image format";
+            // 
+            // comboBox_outputFormat
+            // 
+            this.comboBox_outputFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox_outputFormat.FormattingEnabled = true;
+            this.comboBox_outputFormat.Location = new System.Drawing.Point(95, 122);
+            this.comboBox_outputFormat.Name = "comboBox_outputFormat";
+            this.comboBox_outputFormat.Size = new System.Drawing.Size(198, 21);
+            this.comboBox_outputFormat.SelectedValueChanged += ComboBox_outputFormat_SelectedValueChanged;
+            this.comboBox_outputFormat.TabIndex = 5;
+            // 
+            // SettingsFormDetail
+            // 
+            this.AcceptButton = this.buttonOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-			this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
-			this.CancelButton = this.buttonCancel;
-			this.ClientSize = new System.Drawing.Size(360, 172);
-			this.Controls.Add(this.groupBox1);
-			this.Controls.Add(this.buttonOk);
-			this.Controls.Add(this.buttonCancel);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.LanguageKey = "externalcommand.settings_detail_title";
-			this.Name = "SettingsFormDetail";
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.ResumeLayout(false);
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(360, 204);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.buttonOk);
+            this.Controls.Add(this.buttonCancel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.LanguageKey = "externalcommand.settings_detail_title";
+            this.Name = "SettingsFormDetail";
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.ResumeLayout(false);
 
 		}
-		private GreenshotLabel label1;
+        private GreenshotLabel label1;
 		private GreenshotLabel label2;
 		private GreenshotLabel label3;
 		private GreenshotLabel label4;
-		private GreenshotGroupBox groupBox1;
+        private GreenshotLabel label5;
+        private GreenshotGroupBox groupBox1;
 		private GreenshotButton buttonCancel;
 		private GreenshotButton buttonOk;
 		private System.Windows.Forms.TextBox textBox_commandline;
 		private System.Windows.Forms.TextBox textBox_arguments;
-		private System.Windows.Forms.TextBox textBox_name;
+        private EnumComboBox comboBox_outputFormat;
+        private System.Windows.Forms.TextBox textBox_name;
 		private System.Windows.Forms.Button buttonPathSelect;
 	}
 }

--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -309,20 +309,21 @@ namespace Greenshot.Forms
                     LanguageDialog languageDialog = LanguageDialog.GetInstance();
                     languageDialog.ShowDialog();
                     _conf.Language = languageDialog.SelectedLanguage;
-                    IniConfig.Save();
                 }
 
                 // Check if it's the first time launch?
                 if (_conf.IsFirstLaunch)
                 {
                     _conf.IsFirstLaunch = false;
-                    IniConfig.Save();
                     transport.AddCommand(CommandEnum.FirstLaunch);
                 }
 
                 // Should fix BUG-1633
                 Application.DoEvents();
                 _instance = new MainForm(transport);
+
+                // force saving ini on every start because some init functions could change/fix the configuration. i.e. loading plugins
+                IniConfig.Save();
                 Application.Run();
             }
             catch (Exception ex)


### PR DESCRIPTION
Now it is possible to define the image format for every external command separately.

The default is still PNG.

This references #221.

I can't used `GreenshotComboBox` so i had to move most of it's functionallity to `EnumComboBox`. 
I reused translation from main App.


_Notes: The newly defined commands will only be available after restarting Greenshot. To fix this, #594 is required._