### PR TITLE
[Fix] Missing types in SafeSerializationBinder 

### DIFF
--- a/src/Greenshot/Helpers/CopyData.cs
+++ b/src/Greenshot/Helpers/CopyData.cs
@@ -608,6 +608,10 @@ internal class SafeSerializationBinder : SerializationBinder
     private static readonly Type[] AllowedTypes = new Type[]
     {
         typeof(CopyDataObjectData),
+        typeof(CopyDataTransport),
+        typeof(KeyValuePair<CommandEnum, string>),
+        typeof(List<KeyValuePair<CommandEnum, string>>),
+        typeof(CommandEnum),
     };
 
     public override Type BindToType(string assemblyName, string typeName)


### PR DESCRIPTION
Added all missing types to `SafeSerializationBinder` that are allowed to be sent with WM_COPYDATA.

This fixes #685