### PR TITLE
open Preferences page instead of showing error when running second in…

### DIFF
--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -273,19 +273,10 @@ namespace Greenshot.Forms
                             using Process currentProcess = Process.GetCurrentProcess();
                             instanceInfo.Append(index + ": ").AppendLine(Kernel32Api.GetProcessPath(currentProcess.Id));
                         }
-
-                        // A dirty fix to make sure the message box is visible as a Greenshot window on the taskbar
-                        using Form dummyForm = new Form
+                        using (var settingsForm = new SettingsForm())
                         {
-                            Icon = GreenshotResources.GetGreenshotIcon(),
-                            ShowInTaskbar = true,
-                            FormBorderStyle = FormBorderStyle.None,
-                            Location = new Point(int.MinValue, int.MinValue)
-                        };
-                        dummyForm.Load += delegate { dummyForm.Size = Size.Empty; };
-                        dummyForm.Show();
-                        MessageBox.Show(dummyForm, Language.GetString(LangKey.error_multipleinstances) + "\r\n" + instanceInfo, Language.GetString(LangKey.error),
-                            MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                            settingsForm.ShowDialog();
+                        }
                     }
 
                     FreeMutex();


### PR DESCRIPTION
…stance

instead of displaying an error "an instance of Greenshot is already running", let's show the Preferences page instead. I hear many questions about that error and I think this may be a better user experience. It's a big enough issue you've even got an entry for it in the FAQ. Open to discussion of course!