### PR TITLE
[Fix] compiler error CS9273 in C#14

### DIFF
--- a/src/Greenshot.Plugin.Confluence/EnumDisplayer.cs
+++ b/src/Greenshot.Plugin.Confluence/EnumDisplayer.cs
@@ -67,12 +67,12 @@ namespace Greenshot.Plugin.Confluence
                 }
 
                 var fields = _type.GetFields(BindingFlags.Public | BindingFlags.Static);
-                foreach (var field in fields)
+                foreach (var fieldInfo in fields)
                 {
-                    DisplayKeyAttribute[] a = (DisplayKeyAttribute[]) field.GetCustomAttributes(typeof(DisplayKeyAttribute), false);
+                    DisplayKeyAttribute[] a = (DisplayKeyAttribute[])fieldInfo.GetCustomAttributes(typeof(DisplayKeyAttribute), false);
 
                     string displayKey = GetDisplayKeyValue(a);
-                    object enumValue = field.GetValue(null);
+                    object enumValue = fieldInfo.GetValue(null);
 
                     string displayString;
                     if (displayKey != null && Language.HasKey(displayKey))


### PR DESCRIPTION
Building Greenshot with current .NET SDK and C# 14 causes compiler error [CS9273](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/partial-declarations?f1url=%3FappId%3Droslyn%26k%3Dk(CS9273)#field-backed-properties).

`field` is now a reserved keyword.

To fix this, the variable is renamed to `fileInfo`.