### PR TITLE
Add null check for prepared filter in HighlightContainer fix issue 725 crash

### DIFF
--- a/src/Greenshot.Editor/Drawing/HighlightContainer.cs
+++ b/src/Greenshot.Editor/Drawing/HighlightContainer.cs
@@ -75,7 +75,15 @@ namespace Greenshot.Editor.Drawing
 
         private void ConfigurePreparedFilters()
         {
-            PreparedFilter preset = (PreparedFilter) GetFieldValue(FieldType.PREPARED_FILTER_HIGHLIGHT);
+            object fieldValue = GetFieldValue(FieldType.PREPARED_FILTER_HIGHLIGHT);
+
+            // Guard against null value which can occur after undo operations
+            if (fieldValue == null)
+            {
+                return;
+            }
+
+            PreparedFilter preset = (PreparedFilter)fieldValue;
             while (Filters.Count > 0)
             {
                 Remove(Filters[0]);


### PR DESCRIPTION
Added a guard clause to handle null values returned by GetFieldValue for PREPARED_FILTER_HIGHLIGHT, preventing potential errors after undo operations.

Fix for crash in https://github.com/greenshot/greenshot/issues/725