### PR TITLE
Avoid quality parameter for PNG in file format handler

### DIFF
--- a/src/Greenshot.Editor/FileFormatHandlers/DefaultFileFormatHandler.cs
+++ b/src/Greenshot.Editor/FileFormatHandlers/DefaultFileFormatHandler.cs
@@ -71,13 +71,18 @@ namespace Greenshot.Editor.FileFormatHandlers
             {
                 return false;
             }
-            EncoderParameters parameters = new EncoderParameters(1)
+            // Don't use quality parameter for PNG (it doesn't support it and can cause corruption)
+            EncoderParameters parameters = null;
+            if (imageFormat.Guid != ImageFormat.Png.Guid)
             {
-                Param =
+                parameters = new EncoderParameters(1)
                 {
-                    [0] = new EncoderParameter(Encoder.Quality, surfaceOutputSettings.JPGQuality)
-                }
-            };
+                    Param =
+                    {
+                        [0] = new EncoderParameter(Encoder.Quality, surfaceOutputSettings.JPGQuality)
+                    }
+                };
+            }
             // For those images which are with Alpha, but the format doesn't support this, change it to 24bpp
             if (imageFormat.Guid == ImageFormat.Jpeg.Guid && Image.IsAlphaPixelFormat(bitmap.PixelFormat))
             {


### PR DESCRIPTION
Prevents setting the quality encoder parameter when saving PNG images, as PNG does not support this parameter and it can cause file corruption. The quality parameter is now only set for formats that support it, such as JPEG.

This fixed https://github.com/greenshot/greenshot/issues/743