### PR TITLE
Adjust layout and sizing of expert settings controls

### DIFF
--- a/src/Greenshot.Base/Core/CoreConfiguration.cs
+++ b/src/Greenshot.Base/Core/CoreConfiguration.cs
@@ -129,8 +129,12 @@ namespace Greenshot.Base.Core
         [IniProperty("OutputFileReduceColorsTo", Description = "Amount of colors to reduce to, when reducing", DefaultValue = "256")]
         public int OutputFileReduceColorsTo { get; set; }
 
-        [IniProperty("OutputFileCopyPathToClipboard", Description = "When saving a screenshot, copy the path to the clipboard?", DefaultValue = "true")]
-        public bool OutputFileCopyPathToClipboard { get; set; }
+        [Obsolete("Exists only for backward compatibility")]
+        [IniProperty("OutputFileCopyPathToClipboard", Description = "When saving a screenshot, copy the path to the clipboard?", ExcludeIfNull = true)]
+        public bool? OutputFileCopyPathToClipboard { get; set; }
+
+        [IniProperty("OutputFilePostSaveBehavior", Description = "Behavior after saving a screenshot", DefaultValue = "CopyFilePathToClipboard")]
+        public PostSaveBehavior OutputFilePostSaveBehavior { get; set; }
 
         [IniProperty("OutputFileAsFullpath", Description = "SaveAs Full path?")]
         public string OutputFileAsFullpath { get; set; }
@@ -496,6 +500,20 @@ namespace Greenshot.Base.Core
         /// </summary>
         public override void AfterLoad()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
+            // Migrate old OutputFileCopyPathToClipboard boolean to new PostSaveBehavior enum
+            // Once migrated, the old property is set to null and won't exist in the INI file anymore
+            if (OutputFileCopyPathToClipboard.HasValue)
+            {
+                OutputFilePostSaveBehavior = OutputFileCopyPathToClipboard.Value
+                    ? PostSaveBehavior.CopyFilePathToClipboard
+                    : PostSaveBehavior.None;
+                // Set to null so it won't be written back to the INI file (ExcludeIfNull)
+                OutputFileCopyPathToClipboard = null;
+                IsDirty = true;
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
             // Comment with releases
             // CheckForUnstable = true;
 
@@ -545,12 +563,6 @@ namespace Greenshot.Base.Core
             if (OutputDestinations.Count == 0)
             {
                 OutputDestinations.Add("Editor");
-            }
-
-            // Prevent both settings at once, bug #3435056
-            if (OutputDestinations.Contains("Clipboard") && OutputFileCopyPathToClipboard)
-            {
-                OutputFileCopyPathToClipboard = false;
             }
 
             // Make sure we have clipboard formats, otherwise a paste doesn't make sense!

--- a/src/Greenshot.Base/Core/Enums/PostSaveBehavior.cs
+++ b/src/Greenshot.Base/Core/Enums/PostSaveBehavior.cs
@@ -1,0 +1,33 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Greenshot.Base.Core.Enums
+{
+    /// <summary>
+    /// Defines the behavior after saving a screenshot
+    /// </summary>
+    public enum PostSaveBehavior
+    {
+        None,
+        CopyImageToClipboard,
+        CopyFilePathToClipboard
+    }
+}

--- a/src/Greenshot.Base/Core/ImageIO.cs
+++ b/src/Greenshot.Base/Core/ImageIO.cs
@@ -296,7 +296,7 @@ namespace Greenshot.Base.Core
         /// <summary>
         /// Saves image to specific path with specified quality
         /// </summary>
-        public static void Save(ISurface surface, string fullPath, bool allowOverwrite, SurfaceOutputSettings outputSettings, bool copyPathToClipboard)
+        public static void Save(ISurface surface, string fullPath, bool allowOverwrite, SurfaceOutputSettings outputSettings)
         {
             fullPath = FilenameHelper.MakeFqFilenameSafe(fullPath);
             string path = Path.GetDirectoryName(fullPath);
@@ -323,11 +323,6 @@ namespace Greenshot.Base.Core
             using (FileStream stream = new FileStream(fullPath, FileMode.Create, FileAccess.Write))
             {
                 SaveToStream(surface, stream, outputSettings);
-            }
-
-            if (copyPathToClipboard)
-            {
-                ClipboardHelper.SetClipboardData(fullPath);
             }
         }
 
@@ -377,7 +372,7 @@ namespace Greenshot.Base.Core
                     }
 
                     // TODO: For now we always overwrite, should be changed
-                    Save(surface, fileNameWithExtension, true, outputSettings, CoreConfig.OutputFileCopyPathToClipboard);
+                    Save(surface, fileNameWithExtension, true, outputSettings);
                     returnValue = fileNameWithExtension;
                     IniConfig.Save();
                 }
@@ -419,7 +414,7 @@ namespace Greenshot.Base.Core
             // This is done for e.g. bugs #2974608, #2963943, #2816163, #2795317, #2789218
             try
             {
-                Save(surface, tmpFile, true, outputSettings, false);
+                Save(surface, tmpFile, true, outputSettings);
                 TmpFileCache.Add(tmpFile, tmpFile);
             }
             catch (Exception e)
@@ -482,7 +477,7 @@ namespace Greenshot.Base.Core
 
             try
             {
-                Save(surface, tmpPath, true, outputSettings, false);
+                Save(surface, tmpPath, true, outputSettings);
                 TmpFileCache.Add(tmpPath, tmpPath);
             }
             catch (Exception)

--- a/src/Greenshot.Base/Core/WindowsEnumerator.cs
+++ b/src/Greenshot.Base/Core/WindowsEnumerator.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using Dapplo.Windows.User32;
+using Greenshot.Base.Interop;
 
 namespace Greenshot.Base.Core
 {
@@ -50,6 +51,11 @@ namespace Greenshot.Base.Core
             if (hasParent)
             {
                 parentText = User32Api.GetText(hWndParent);
+                // Fallback for Chromium-based browsers where GetWindowText fails
+                if (string.IsNullOrEmpty(parentText))
+                {
+                    parentText = WindowTitleHelper.GetWindowTitle(hWndParent);
+                }
             }
 
             var windows = new List<WindowDetails>();

--- a/src/Greenshot.Base/Greenshot.Base.csproj
+++ b/src/Greenshot.Base/Greenshot.Base.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Svg" Version="3.4.3" />
     <Reference Include="Accessibility" />
     <Reference Include="CustomMarshalers" />
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationTypes" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="log4net-embedded.xml" />

--- a/src/Greenshot.Base/Interop/WindowTitleHelper.cs
+++ b/src/Greenshot.Base/Interop/WindowTitleHelper.cs
@@ -1,0 +1,83 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2007-2021 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Base.Interop
+{
+    /// <summary>
+    /// Helper for retrieving window titles from sandboxed applications (Chrome, Edge, Brave)
+    /// where GetWindowText fails due to cross-process security restrictions.
+    /// </summary>
+    public static class WindowTitleHelper
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out int processId);
+
+        /// <summary>
+        /// Gets the window title via Process.MainWindowTitle as a fallback for sandboxed browsers.
+        /// </summary>
+        /// <param name="hWnd">The window handle</param>
+        /// <returns>The window title, or null if retrieval fails</returns>
+        public static string GetWindowTitle(IntPtr hWnd)
+        {
+            if (hWnd == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                GetWindowThreadProcessId(hWnd, out int processId);
+                if (processId == 0)
+                {
+                    return null;
+                }
+
+                using var process = Process.GetProcessById(processId);
+                if (process.MainWindowHandle == hWnd && !string.IsNullOrEmpty(process.MainWindowTitle))
+                {
+                    return process.MainWindowTitle;
+                }
+
+                return null;
+            }
+            catch (ArgumentException)
+            {
+                // Process no longer exists
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                // Process has exited
+                return null;
+            }
+            catch (Win32Exception)
+            {
+                // Access denied or other Win32 error
+                return null;
+            }
+        }
+    }
+}

--- a/src/Greenshot/Destinations/FileDestination.cs
+++ b/src/Greenshot/Destinations/FileDestination.cs
@@ -26,6 +26,7 @@ using System.Windows.Forms;
 using Greenshot.Base;
 using Greenshot.Base.Controls;
 using Greenshot.Base.Core;
+using Greenshot.Base.Core.Enums;
 using Greenshot.Base.IniFile;
 using Greenshot.Base.Interfaces;
 using Greenshot.Base.Interfaces.Plugin;
@@ -87,7 +88,7 @@ namespace Greenshot.Destinations
             // This is done for e.g. bugs #2974608, #2963943, #2816163, #2795317, #2789218, #3004642
             try
             {
-                ImageIO.Save(surface, fullPath, overwrite, outputSettings, CoreConfig.OutputFileCopyPathToClipboard);
+                ImageIO.Save(surface, fullPath, overwrite, outputSettings);
                 outputMade = true;
             }
             catch (ArgumentException ex1)
@@ -119,6 +120,20 @@ namespace Greenshot.Destinations
                 }
 
                 CoreConfig.OutputFileAsFullpath = fullPath;
+
+                // Handle post-save behavior (copy to clipboard based on user setting)
+                switch (CoreConfig.OutputFilePostSaveBehavior)
+                {
+                    case PostSaveBehavior.CopyImageToClipboard:
+                        ClipboardHelper.SetClipboardData(surface);
+                        break;
+                    case PostSaveBehavior.CopyFilePathToClipboard:
+                        ClipboardHelper.SetClipboardData(fullPath);
+                        break;
+                    case PostSaveBehavior.None:
+                        // Do nothing
+                        break;
+                }
             }
 
             ProcessExport(exportInformation, surface);

--- a/src/Greenshot/Destinations/FileWithDialogDestination.cs
+++ b/src/Greenshot/Destinations/FileWithDialogDestination.cs
@@ -23,6 +23,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using Greenshot.Base;
 using Greenshot.Base.Core;
+using Greenshot.Base.Core.Enums;
 using Greenshot.Base.IniFile;
 using Greenshot.Base.Interfaces;
 using Greenshot.Configuration;
@@ -64,6 +65,20 @@ namespace Greenshot.Destinations
                 exportInformation.Filepath = savedTo;
                 captureDetails.Filename = savedTo;
                 conf.OutputFileAsFullpath = savedTo;
+
+                // Handle post-save behavior (copy to clipboard based on user setting)
+                switch (conf.OutputFilePostSaveBehavior)
+                {
+                    case PostSaveBehavior.CopyImageToClipboard:
+                        ClipboardHelper.SetClipboardData(surface);
+                        break;
+                    case PostSaveBehavior.CopyFilePathToClipboard:
+                        ClipboardHelper.SetClipboardData(savedTo);
+                        break;
+                    case PostSaveBehavior.None:
+                        // Do nothing
+                        break;
+                }
             }
 
             ProcessExport(exportInformation, surface);

--- a/src/Greenshot/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot/Forms/SettingsForm.Designer.cs
@@ -67,7 +67,8 @@ namespace Greenshot.Forms {
 			this.label_primaryimageformat = new GreenshotLabel();
 			this.groupbox_preferredfilesettings = new GreenshotGroupBox();
 			this.btnPatternHelp = new System.Windows.Forms.Button();
-			this.checkbox_copypathtoclipboard = new GreenshotCheckBox();
+			this.label_postsavebehavior = new GreenshotLabel();
+			this.combobox_postsavebehavior = new GreenshotComboBox();
 			this.checkbox_zoomer = new GreenshotCheckBox();
 			this.groupbox_applicationsettings = new GreenshotGroupBox();
 			this.checkbox_autostartshortcut = new GreenshotCheckBox();
@@ -281,7 +282,8 @@ namespace Greenshot.Forms {
 			// groupbox_preferredfilesettings
 			// 
 			this.groupbox_preferredfilesettings.Controls.Add(this.btnPatternHelp);
-			this.groupbox_preferredfilesettings.Controls.Add(this.checkbox_copypathtoclipboard);
+			this.groupbox_preferredfilesettings.Controls.Add(this.label_postsavebehavior);
+			this.groupbox_preferredfilesettings.Controls.Add(this.combobox_postsavebehavior);
 			this.groupbox_preferredfilesettings.Controls.Add(this.combobox_primaryimageformat);
 			this.groupbox_preferredfilesettings.Controls.Add(this.label_primaryimageformat);
 			this.groupbox_preferredfilesettings.Controls.Add(this.label_storagelocation);
@@ -305,17 +307,25 @@ namespace Greenshot.Forms {
 			this.btnPatternHelp.Text = "?";
 			this.btnPatternHelp.UseVisualStyleBackColor = true;
 			this.btnPatternHelp.Click += new System.EventHandler(this.BtnPatternHelpClick);
-			// 
-			// checkbox_copypathtoclipboard
-			// 
-			this.checkbox_copypathtoclipboard.LanguageKey = "settings_copypathtoclipboard";
-			this.checkbox_copypathtoclipboard.Location = new System.Drawing.Point(12, 89);
-			this.checkbox_copypathtoclipboard.Name = "checkbox_copypathtoclipboard";
-			this.checkbox_copypathtoclipboard.PropertyName = nameof(CoreConfiguration.OutputFileCopyPathToClipboard);
-			this.checkbox_copypathtoclipboard.Size = new System.Drawing.Size(394, 24);
-			this.checkbox_copypathtoclipboard.TabIndex = 6;
-			this.checkbox_copypathtoclipboard.UseVisualStyleBackColor = true;
-			// 
+			//
+			// label_postsavebehavior
+			//
+			this.label_postsavebehavior.LanguageKey = "settings_postsavebehavior";
+			this.label_postsavebehavior.Location = new System.Drawing.Point(6, 92);
+			this.label_postsavebehavior.Name = "label_postsavebehavior";
+			this.label_postsavebehavior.Size = new System.Drawing.Size(126, 19);
+			this.label_postsavebehavior.TabIndex = 6;
+			//
+			// combobox_postsavebehavior
+			//
+			this.combobox_postsavebehavior.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.combobox_postsavebehavior.FormattingEnabled = true;
+			this.combobox_postsavebehavior.Location = new System.Drawing.Point(138, 89);
+			this.combobox_postsavebehavior.Name = "combobox_postsavebehavior";
+			this.combobox_postsavebehavior.PropertyName = nameof(CoreConfiguration.OutputFilePostSaveBehavior);
+			this.combobox_postsavebehavior.Size = new System.Drawing.Size(268, 21);
+			this.combobox_postsavebehavior.TabIndex = 7;
+			//
             // groupbox_applicationsettings
 			// 
 			this.groupbox_applicationsettings.Controls.Add(this.label_language);
@@ -421,7 +431,7 @@ namespace Greenshot.Forms {
 			this.trackBarJpegQuality.Scroll += new System.EventHandler(this.TrackBarJpegQualityScroll);
 			// 
 			// groupbox_destination
-			// 
+			//
 			this.groupbox_destination.Controls.Add(this.checkbox_picker);
 			this.groupbox_destination.Controls.Add(this.listview_destinations);
 			this.groupbox_destination.LanguageKey = "settings_destination";
@@ -430,9 +440,9 @@ namespace Greenshot.Forms {
 			this.groupbox_destination.Size = new System.Drawing.Size(412, 311);
 			this.groupbox_destination.TabIndex = 16;
 			this.groupbox_destination.TabStop = false;
-			// 
+			//
 			// checkbox_picker
-			// 
+			//
 			this.checkbox_picker.LanguageKey = "settings_destination_picker";
 			this.checkbox_picker.Location = new System.Drawing.Point(6, 14);
 			this.checkbox_picker.Name = "checkbox_picker";
@@ -440,7 +450,7 @@ namespace Greenshot.Forms {
 			this.checkbox_picker.TabIndex = 1;
 			this.checkbox_picker.UseVisualStyleBackColor = true;
 			this.checkbox_picker.CheckStateChanged += new System.EventHandler(this.DestinationsCheckStateChanged);
-			// 
+			//
 			// listview_destinations
 			// 
 			this.listview_destinations.Alignment = System.Windows.Forms.ListViewAlignment.Left;
@@ -1198,7 +1208,7 @@ namespace Greenshot.Forms {
 			// checkbox_optimizeforrdp
 			//
 			this.checkbox_optimizeforrdp.LanguageKey = "expertsettings_optimizeforrdp";
-			this.checkbox_optimizeforrdp.Location = new System.Drawing.Point(10, 130);
+			this.checkbox_optimizeforrdp.Location = new System.Drawing.Point(10, 136);
 			this.checkbox_optimizeforrdp.Name = "checkbox_optimizeforrdp";
 			this.checkbox_optimizeforrdp.PropertyName = nameof(coreConfiguration.OptimizeForRDP);
 			this.checkbox_optimizeforrdp.Size = new System.Drawing.Size(394, 17);
@@ -1347,7 +1357,8 @@ namespace Greenshot.Forms {
 		private GreenshotGroupBox groupbox_plugins;
 		private GreenshotTabPage tab_plugins;
 		private System.Windows.Forms.Button btnPatternHelp;
-		private GreenshotCheckBox checkbox_copypathtoclipboard;
+		private GreenshotLabel label_postsavebehavior;
+		private GreenshotComboBox combobox_postsavebehavior;
 		private GreenshotTabPage tab_output;
 		private GreenshotTabPage tab_general;
 		private System.Windows.Forms.TabControl tabcontrol;

--- a/src/Greenshot/Forms/SettingsForm.cs
+++ b/src/Greenshot/Forms/SettingsForm.cs
@@ -495,6 +495,10 @@ namespace Greenshot.Forms
             combobox_window_capture_mode.Enabled = !coreConfiguration.CaptureWindowsInteractive && !coreConfiguration.Values["WindowCaptureMode"].IsFixed;
             radiobuttonWindowCapture.Checked = !coreConfiguration.CaptureWindowsInteractive;
 
+            // Populate post-save behavior combobox
+            PostSaveBehavior[] postSaveBehaviors = new[] { PostSaveBehavior.None, PostSaveBehavior.CopyImageToClipboard, PostSaveBehavior.CopyFilePathToClipboard };
+            PopulateComboBox(combobox_postsavebehavior, postSaveBehaviors, coreConfiguration.OutputFilePostSaveBehavior);
+
             trackBarJpegQuality.Value = coreConfiguration.OutputFileJpegQuality;
             trackBarJpegQuality.Enabled = !coreConfiguration.Values["OutputFileJpegQuality"].IsFixed;
             textBoxJpegQuality.Text = coreConfiguration.OutputFileJpegQuality + "%";
@@ -562,6 +566,7 @@ namespace Greenshot.Forms
             coreConfiguration.ClipboardFormats = clipboardFormats;
 
             coreConfiguration.WindowCaptureMode = GetSelected<WindowCaptureMode>(combobox_window_capture_mode);
+            coreConfiguration.OutputFilePostSaveBehavior = GetSelected<PostSaveBehavior>(combobox_postsavebehavior);
             if (!FilenameHelper.FillVariables(coreConfiguration.OutputFilePath, false).Equals(textbox_storagelocation.Text))
             {
                 coreConfiguration.OutputFilePath = textbox_storagelocation.Text;
@@ -730,7 +735,6 @@ namespace Greenshot.Forms
         /// </summary>
         private void CheckDestinationSettings()
         {
-            bool clipboardDestinationChecked = false;
             bool pickerSelected = checkbox_picker.Checked;
             bool destinationsEnabled = true;
             if (coreConfiguration.Values.ContainsKey("Destinations"))
@@ -739,16 +743,6 @@ namespace Greenshot.Forms
             }
 
             listview_destinations.Enabled = destinationsEnabled;
-
-            foreach (int index in listview_destinations.CheckedIndices)
-            {
-                ListViewItem item = listview_destinations.Items[index];
-                if (item.Tag is IDestination destinationFromTag && destinationFromTag.Designation.Equals(nameof(WellKnownDestinations.Clipboard)))
-                {
-                    clipboardDestinationChecked = true;
-                    break;
-                }
-            }
 
             if (pickerSelected)
             {
@@ -761,16 +755,7 @@ namespace Greenshot.Forms
             }
             else
             {
-                // Prevent multiple clipboard settings at once, see bug #3435056
-                if (clipboardDestinationChecked)
-                {
-                    checkbox_copypathtoclipboard.Checked = false;
-                    checkbox_copypathtoclipboard.Enabled = false;
-                }
-                else
-                {
-                    checkbox_copypathtoclipboard.Enabled = true;
-                }
+                combobox_postsavebehavior.Enabled = true;
             }
         }
 

--- a/src/Greenshot/Languages/language-ca-CA.xml
+++ b/src/Greenshot/Languages/language-ca-CA.xml
@@ -218,7 +218,7 @@ Si us plau, verifiqueu el camí d'accés seleccionat.</resource>
 		<resource name="settings_destination_email">Correu electrònic</resource>
 		<resource name="settings_destination_file">Desa directament (utilitzant la configuració indicada a sota)</resource>
 		<resource name="settings_destination_fileas">Anomena i desa (es mostra el quadre de diàleg)</resource>
-		<resource name="settings_destination_picker">Selecciona el destí dinàmicament</resource>
+		<resource name="settings_destination_picker">Selecciona el destí cada vegada</resource>
 		<resource name="settings_destination_printer">Envia a la impressora</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Format del nom de fitxer</resource>

--- a/src/Greenshot/Languages/language-cs-CZ.xml
+++ b/src/Greenshot/Languages/language-cs-CZ.xml
@@ -219,7 +219,7 @@ Zkontrolujte prosím dostupnost vybraného cíle.</resource>
 		<resource name="settings_destination_email">E-mail</resource>
 		<resource name="settings_destination_file">Uložit přímo (pomocí nastavení níže)</resource>
 		<resource name="settings_destination_fileas">Uložit jako (zobrazit dialog)</resource>
-		<resource name="settings_destination_picker">Vybrat cíl dynamicky</resource>
+		<resource name="settings_destination_picker">Vybrat cíl pokaždé</resource>
 		<resource name="settings_destination_printer">Odeslat na tiskárnu</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Vzor pro název souboru</resource>

--- a/src/Greenshot/Languages/language-de-DE.xml
+++ b/src/Greenshot/Languages/language-de-DE.xml
@@ -222,7 +222,7 @@ Bitte überprüfen Sie die Schreibrechte oder wählen Sie einen anderen Speicher
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Sofort speichern</resource>
 		<resource name="settings_destination_fileas">Speichern unter... (mit Dialog)</resource>
-		<resource name="settings_destination_picker">Ziel dynamisch auswählen</resource>
+		<resource name="settings_destination_picker">Ziel jedes Mal auswählen</resource>
 		<resource name="settings_destination_printer">An Drucker senden</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Dateinamensmuster</resource>

--- a/src/Greenshot/Languages/language-de-x-franconia.xml
+++ b/src/Greenshot/Languages/language-de-x-franconia.xml
@@ -207,7 +207,7 @@ Schau hald amal, obsd da übbahabds hi schreim däffsd oder duhs woannersch hi.<
 		<resource name="settings_destination_email">I-Mehl</resource>
 		<resource name="settings_destination_file">Sofodd schbeichern</resource>
 		<resource name="settings_destination_fileas">Schbeichern under (mit Dialooch)</resource>
-		<resource name="settings_destination_picker">Schdändich froong</resource>
+		<resource name="settings_destination_picker">Ziel jedesmol auswähln</resource>
 		<resource name="settings_destination_printer">An Drugger schiggn</resource>
 		<resource name="settings_editor">Edidor</resource>
 		<resource name="settings_filenamepattern">Dadeinamen-Musder</resource>

--- a/src/Greenshot/Languages/language-el-GR.xml
+++ b/src/Greenshot/Languages/language-el-GR.xml
@@ -226,7 +226,7 @@
 		<resource name="settings_destination_email">Αποστολή στιγμιότυπου με e-mail</resource>
 		<resource name="settings_destination_file">Άμεση αποθήκευση (με τις παρακάτω ρυθμίσεις)</resource>
 		<resource name="settings_destination_fileas">Αποθήκευση ως (εμφάνιση διαλόγου)</resource>
-		<resource name="settings_destination_picker">Δυναμική επιλογή προορισμού</resource>
+		<resource name="settings_destination_picker">Επιλογή προορισμού κάθε φορά</resource>
 		<resource name="settings_destination_printer">Αποστολή για Εκτύπωση</resource>
 		<resource name="settings_editor">Παράθυρο επεξεργασίας</resource>
 		<resource name="settings_filenamepattern">Πρότυπο όνομα αρχείου</resource>

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -217,13 +217,14 @@ Please check write accessibility of the selected storage location.</resource>
 		<resource name="settings_checkperiod">Update check interval in days (0=no check)</resource>
 		<resource name="settings_configureplugin">Configure</resource>
 		<resource name="settings_copypathtoclipboard">Copy file path to clipboard every time an image is saved</resource>
+		<resource name="settings_postsavebehavior">Behavior after saving</resource>
 		<resource name="settings_destination">Destination</resource>
 		<resource name="settings_destination_clipboard">Copy to clipboard</resource>
 		<resource name="settings_destination_editor">Open in image editor</resource>
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Save directly (using settings below)</resource>
 		<resource name="settings_destination_fileas">Save as (displaying dialog)</resource>
-		<resource name="settings_destination_picker">Select destination dynamically</resource>
+		<resource name="settings_destination_picker">Select destination every time</resource>
 		<resource name="settings_destination_printer">Send to printer</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Filename pattern</resource>
@@ -291,6 +292,9 @@ All Greenshot features still work directly from the tray icon context menu witho
 		<resource name="WindowCaptureMode.Auto">Automatically</resource>
 		<resource name="WindowCaptureMode.GDI">Use default color</resource>
 		<resource name="WindowCaptureMode.Screen">As displayed</resource>
+		<resource name="PostSaveBehavior.None">None</resource>
+		<resource name="PostSaveBehavior.CopyImageToClipboard">Copy image to clipboard</resource>
+		<resource name="PostSaveBehavior.CopyFilePathToClipboard">Copy file path to clipboard</resource>
 
     <!-- 1.2 -->
     <resource name="editor_dropshadow_darkness">Shadow darkness</resource>

--- a/src/Greenshot/Languages/language-es-ES.xml
+++ b/src/Greenshot/Languages/language-es-ES.xml
@@ -199,7 +199,7 @@ Por favor verifique la ruta de almacenamiento seleccionada.</resource>
 		<resource name="settings_destination_email">Correo electrónico</resource>
 		<resource name="settings_destination_file">Guardar directamente (usando la configuración indicada abajo)</resource>
 		<resource name="settings_destination_fileas">Guardar como (mostrando cuadro)</resource>
-		<resource name="settings_destination_picker">Seleccionar destino dinámicamente</resource>
+		<resource name="settings_destination_picker">Seleccionar destino cada vez</resource>
 		<resource name="settings_destination_printer">Enviar a imprimir</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Formato para nombre del archivo</resource>

--- a/src/Greenshot/Languages/language-et-EE.xml
+++ b/src/Greenshot/Languages/language-et-EE.xml
@@ -225,7 +225,7 @@ Palun kontrollige valitud hoiuala kirjutamisõigust.</resource>
 		<resource name="settings_destination_email">E-post</resource>
 		<resource name="settings_destination_file">Salvestage otse (kasutades kõrvalolevaid seadeid)</resource>
 		<resource name="settings_destination_fileas">Salvestega nimega (dialoogi kuvamin)</resource>
-		<resource name="settings_destination_picker">Valige asukoht dünaamiliselt</resource>
+		<resource name="settings_destination_picker">Valige sihtkoht iga kord</resource>
 		<resource name="settings_destination_printer">Saatke printerisse</resource>
 		<resource name="settings_editor">Kohandaja</resource>
 		<resource name="settings_filenamepattern">Faili nime atribuudid</resource>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -239,7 +239,7 @@ Veuillez vérifier l'accessibilité du répertoire de stockage.</resource>
 		<resource name="settings_destination_email">Courriel</resource>
 		<resource name="settings_destination_file">Enregistrez directement (en utilisant les paramètres ci-dessous)</resource>
 		<resource name="settings_destination_fileas">Enregistrer sous (afficher la boîte de dialogue)</resource>
-		<resource name="settings_destination_picker">Sélectionner la destination dynamiquement</resource>
+		<resource name="settings_destination_picker">Sélectionner la destination à chaque fois</resource>
 		<resource name="settings_destination_printer">Vers l'imprimante</resource>
 		<resource name="settings_editor">Éditeur</resource>
 		<resource name="settings_filenamepattern">Modèle du nom de fichier</resource>

--- a/src/Greenshot/Languages/language-fr-QC.xml
+++ b/src/Greenshot/Languages/language-fr-QC.xml
@@ -202,7 +202,7 @@ Veuillez vérifier que vous avez l'autorisation d'écrire dans le répertoire de
 		<resource name="settings_destination_email">Courriel</resource>
 		<resource name="settings_destination_file">Sauv. directe (paramètres ci-dessous)</resource>
 		<resource name="settings_destination_fileas">Sauvegarder sous...</resource>
-		<resource name="settings_destination_picker">Choisir la destination dynamiquement</resource>
+		<resource name="settings_destination_picker">Choisir la destination à chaque fois</resource>
 		<resource name="settings_destination_printer">Envoyer à l'imprimante</resource>
 		<resource name="settings_editor">Editeur</resource>
 		<resource name="settings_filenamepattern">Motif du nom de fichier</resource>

--- a/src/Greenshot/Languages/language-id-ID.xml
+++ b/src/Greenshot/Languages/language-id-ID.xml
@@ -238,7 +238,7 @@ Harap cek aksesibilitas menuis pada lokasi penyimpanan yang dipilih.</resource>
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Simpan cepat (menggunakan pengaturan berikut)</resource>
 		<resource name="settings_destination_fileas">Simpan sebagai (tampilkan dialog)</resource>
-		<resource name="settings_destination_picker">Pilih destinasi secara dinamis</resource>
+		<resource name="settings_destination_picker">Pilih destinasi setiap kali</resource>
 		<resource name="settings_destination_printer">Kirim ke printer</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Pola nama berkas</resource>

--- a/src/Greenshot/Languages/language-it-IT.xml
+++ b/src/Greenshot/Languages/language-it-IT.xml
@@ -229,7 +229,7 @@ Correggi la maschera noem file e riprova.</resource>
         <resource name="settings_destination_email">Email</resource>
         <resource name="settings_destination_file">Salva direttamente (usando impostazioni indicate qui sotto)</resource>
         <resource name="settings_destination_fileas">Salva come (visualizzando le scelte)</resource>
-        <resource name="settings_destination_picker">Scegli dinamicamente la destinazione</resource>
+        <resource name="settings_destination_picker">Seleziona destinazione ogni volta</resource>
         <resource name="settings_destination_printer">Invia alla stampante</resource>
         <resource name="settings_editor">Gestione immagini</resource>
         <resource name="settings_filenamepattern">Modello nome file</resource>

--- a/src/Greenshot/Languages/language-kab-DZ.xml
+++ b/src/Greenshot/Languages/language-kab-DZ.xml
@@ -239,7 +239,7 @@ Ma ulac aɣilif senqed tuffart n ukaram n usekles.</resource>
 		<resource name="settings_destination_email">Imayl</resource>
 		<resource name="settings_destination_file">Sekles s srid (s useqdec n iɣewwaṛen daw-a)</resource>
 		<resource name="settings_destination_fileas">Sekles s yisem (sken asfaylu n udiwenni)</resource>
-		<resource name="settings_destination_picker">Fren taniɣert tamussant</resource>
+		<resource name="settings_destination_picker">Fren taniɣert yal tikelt</resource>
 		<resource name="settings_destination_printer">Ar tsaggazt</resource>
 		<resource name="settings_editor">Amaẓrag</resource>
 		<resource name="settings_filenamepattern">Taneɣruft n ufaylu</resource>

--- a/src/Greenshot/Languages/language-ko-KR.xml
+++ b/src/Greenshot/Languages/language-ko-KR.xml
@@ -217,7 +217,7 @@ Also, we would highly appreciate if you checked whether a tracker item already e
 		<resource name="settings_destination_email">이메일</resource>
 		<resource name="settings_destination_file">직접 저장 (아래 설정 사용)</resource>
 		<resource name="settings_destination_fileas">다른 이름으로 저장</resource>
-		<resource name="settings_destination_picker">동적으로 저장할 방법 선택</resource>
+		<resource name="settings_destination_picker">매번 대상 선택</resource>
 		<resource name="settings_destination_printer">인쇄기로 보내기</resource>
 		<resource name="settings_editor">편집기</resource>
 		<resource name="settings_filenamepattern">파일명 유형</resource>

--- a/src/Greenshot/Languages/language-lv-LV.xml
+++ b/src/Greenshot/Languages/language-lv-LV.xml
@@ -217,7 +217,7 @@ Pārbaudi dotajā vietā savas piekļuves tiesības.</resource>
 		<resource name="settings_destination_email">E-pasts</resource>
 		<resource name="settings_destination_file">Saglabāt nejautājot (izmantojot zemākesošos iestatījumus)</resource>
 		<resource name="settings_destination_fileas">Saglabāt kā (tiks vaicāts)</resource>
-		<resource name="settings_destination_picker">Piedāvāt iespējas</resource>
+		<resource name="settings_destination_picker">Izvēlēties galamērķi katru reizi</resource>
 		<resource name="settings_destination_printer">Drukāt</resource>
 		<resource name="settings_editor">Redaktors</resource>
 		<resource name="settings_filenamepattern">Faila vārda paraugs</resource>

--- a/src/Greenshot/Languages/language-nl-NL.xml
+++ b/src/Greenshot/Languages/language-nl-NL.xml
@@ -219,7 +219,7 @@ Controleer de toegangsrechten voor de betreffende locatie.</resource>
 		<resource name="settings_destination_email">E-mail</resource>
 		<resource name="settings_destination_file">Direct opslaan (Onderstaande instellingen gebruiken)</resource>
 		<resource name="settings_destination_fileas">Opslaan als… (via dialoog)</resource>
-		<resource name="settings_destination_picker">Bestemming interactief selecteren</resource>
+		<resource name="settings_destination_picker">Bestemming elke keer selecteren</resource>
 		<resource name="settings_destination_printer">Naar printer</resource>
 		<resource name="settings_editor">Beeldbewerker</resource>
 		<resource name="settings_filenamepattern">Bestandsnaam</resource>

--- a/src/Greenshot/Languages/language-nn-NO.xml
+++ b/src/Greenshot/Languages/language-nn-NO.xml
@@ -197,7 +197,7 @@ Har du skrivetilgang til det valde området?</resource>
 		<resource name="settings_destination_email">Send med e-post</resource>
 		<resource name="settings_destination_file">Lagre (med instillingane under)</resource>
 		<resource name="settings_destination_fileas">Lagre som (med dialogboks)</resource>
-		<resource name="settings_destination_picker">Bruk dynamisk målveljar</resource>
+		<resource name="settings_destination_picker">Vel mål kvar gong</resource>
 		<resource name="settings_destination_printer">Send til utskrift</resource>
 		<resource name="settings_editor">Knipsfiksar</resource>
 		<resource name="settings_filenamepattern">Regel for filnamn</resource>

--- a/src/Greenshot/Languages/language-pl-PL.xml
+++ b/src/Greenshot/Languages/language-pl-PL.xml
@@ -226,7 +226,7 @@ Sprawdź możliwość zapisu w wybranej lokalizacji.</resource>
 		<resource name="settings_destination_email">Wyślij e-mailem</resource>
 		<resource name="settings_destination_file">Zapisz bezpośrednio (wg ustawień poniżej)</resource>
 		<resource name="settings_destination_fileas">Zapisz jako (z oknem dialogowym)</resource>
-		<resource name="settings_destination_picker">Wybieraj miejsce dynamicznie</resource>
+		<resource name="settings_destination_picker">Wybieraj miejsce docelowe za każdym razem</resource>
 		<resource name="settings_destination_printer">Wyślij do drukarki</resource>
 		<resource name="settings_editor">Edytor</resource>
 		<resource name="settings_filenamepattern">Szablon nazwy pliku</resource>

--- a/src/Greenshot/Languages/language-pt-BR.xml
+++ b/src/Greenshot/Languages/language-pt-BR.xml
@@ -200,7 +200,7 @@
 		<resource name="settings_destination_email">Enviar por e-mail</resource>
 		<resource name="settings_destination_file">Salvar em um arquivo</resource>
 		<resource name="settings_destination_fileas">Salvar como... (mostrar caixa de diálogo)</resource>
-		<resource name="settings_destination_picker">Selecione o destino dinamicamente</resource>
+		<resource name="settings_destination_picker">Selecione o destino sempre</resource>
 		<resource name="settings_destination_printer">Enviar para impressora</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Formato do nome</resource>

--- a/src/Greenshot/Languages/language-pt-PT.xml
+++ b/src/Greenshot/Languages/language-pt-PT.xml
@@ -217,7 +217,7 @@ Por favor verifique as permissões de escrita do local seleccionado.</resource>
 		<resource name="settings_destination_email">Enviar por e-mail</resource>
 		<resource name="settings_destination_file">Guardar directamente (usando definições abaixo)</resource>
 		<resource name="settings_destination_fileas">Guardar como (exibir caixa de diálogo)</resource>
-		<resource name="settings_destination_picker">Seleccionar destino dinamicamente</resource>
+		<resource name="settings_destination_picker">Selecionar destino sempre</resource>
 		<resource name="settings_destination_printer">Enviar para impressora</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Nome Ficheiro Padrão</resource>

--- a/src/Greenshot/Languages/language-ru-RU.xml
+++ b/src/Greenshot/Languages/language-ru-RU.xml
@@ -226,7 +226,7 @@ Greenshot поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ.�
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Сохранить непосредственно (с помощью параметров ниже)</resource>
 		<resource name="settings_destination_fileas">Сохранить как (отображать диалоговое окно)</resource>
-		<resource name="settings_destination_picker">Выберите пункт назначения</resource>
+		<resource name="settings_destination_picker">Выбирать место назначения каждый раз</resource>
 		<resource name="settings_destination_printer">Отправить на печать</resource>
 		<resource name="settings_editor">Редактор</resource>
 		<resource name="settings_filenamepattern">Шаблон имени файла</resource>

--- a/src/Greenshot/Languages/language-sk-SK.xml
+++ b/src/Greenshot/Languages/language-sk-SK.xml
@@ -203,7 +203,7 @@ Skontrolujte prosím možnosť zapisovať do vybraného umiestnenia.</resource>
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Uložiť priamo (pomocou nastavení nižšie)</resource>
 		<resource name="settings_destination_fileas">Uložiť ako (zobraz dialóg)</resource>
-		<resource name="settings_destination_picker">Vyberte cieľ dynamicky</resource>		
+		<resource name="settings_destination_picker">Vyberte cieľ zakaždým</resource>
 		<resource name="settings_destination_printer">Poslať do tlačiarne</resource>
 		<resource name="settings_editor">Editor</resource>
 		<resource name="settings_filenamepattern">Meno súboru - šablona</resource>

--- a/src/Greenshot/Languages/language-sl-SI.xml
+++ b/src/Greenshot/Languages/language-sl-SI.xml
@@ -195,7 +195,7 @@ Prosim preverite pravice pisanja v ta direktorij.</resource>
 		<resource name="settings_destination_editor">Odpri v urejevalniku</resource>
 		<resource name="settings_destination_file">Shrani neposredno (z uporabo spodnjih nastavitev)</resource>
 		<resource name="settings_destination_fileas">Shrani kot (odpre pogovorno okno)</resource>
-		<resource name="settings_destination_picker">Dinamično izberi cilj</resource>
+		<resource name="settings_destination_picker">Izberi cilj vsakič</resource>
 		<resource name="settings_destination_printer">Tiskaj</resource>
 		<resource name="settings_editor">Urejevalnik</resource>
 		<resource name="settings_filenamepattern">Vzorec imena datoteke</resource>

--- a/src/Greenshot/Languages/language-sr-RS.xml
+++ b/src/Greenshot/Languages/language-sr-RS.xml
@@ -197,7 +197,7 @@
 		<resource name="settings_destination_email">Е-пошта</resource>
 		<resource name="settings_destination_file">Сачувај директно (уз коришћење доњих поставки)</resource>
 		<resource name="settings_destination_fileas">Сачувај као (уз приказивање прозорчета)</resource>
-		<resource name="settings_destination_picker">Динамички изабери одредиште</resource>
+		<resource name="settings_destination_picker">Изабери одредиште сваки пут</resource>
 		<resource name="settings_destination_printer">Пошаљи штампачу</resource>
 		<resource name="settings_editor">Уређивач</resource>
 		<resource name="settings_filenamepattern">Образац за називе:</resource>

--- a/src/Greenshot/Languages/language-sv-SE.xml
+++ b/src/Greenshot/Languages/language-sv-SE.xml
@@ -218,7 +218,7 @@ Kontrollera skrivrättigheterna för den valda mappen.</resource>
 		<resource name="settings_destination_email">E-mail</resource>
 		<resource name="settings_destination_file">Spara direkt (använd inställningarna nedanför)</resource>
 		<resource name="settings_destination_fileas">Spara som (visa dialogruta)</resource>
-		<resource name="settings_destination_picker">Välj destination dynamiskt</resource>
+		<resource name="settings_destination_picker">Välj destination varje gång</resource>
 		<resource name="settings_destination_printer">Skicka till skrivare</resource>
 		<resource name="settings_editor">Redigerare</resource>
 		<resource name="settings_filenamepattern">Filnamnsmönster</resource>

--- a/src/Greenshot/Languages/language-tr-TR.xml
+++ b/src/Greenshot/Languages/language-tr-TR.xml
@@ -198,7 +198,7 @@ Seçili kayıt yolunun yazılabilir olduğundan emin olun.</resource>
 		<resource name="settings_destination_email">E-Posta gönder</resource>
 		<resource name="settings_destination_file">Aşağıdaki ayarları kullanarak kaydet</resource>
 		<resource name="settings_destination_fileas">Farklı kaydet (ayar penceresini göster)</resource>
-		<resource name="settings_destination_picker">Hedefi dinamik olarak seç</resource>
+		<resource name="settings_destination_picker">Her seferinde hedef seç</resource>
 		<resource name="settings_destination_printer">Yazıcıya gönder</resource>
 		<resource name="settings_editor">Editör</resource>
 		<resource name="settings_filenamepattern">Dosya adı biçimi</resource>

--- a/src/Greenshot/Languages/language-uk-UA.xml
+++ b/src/Greenshot/Languages/language-uk-UA.xml
@@ -218,7 +218,7 @@ Greenshot постачається АБСОЛЮТНО БЕЗ ГАРАНТІЇ. �
 		<resource name="settings_destination_email">Ел. пошта</resource>
 		<resource name="settings_destination_file">Безпосереднє збереження (використовуючи параметри нижче)</resource>
 		<resource name="settings_destination_fileas">Зберегти як (відображення діалогу)</resource>
-		<resource name="settings_destination_picker">Динамічний вибір призначення</resource>
+		<resource name="settings_destination_picker">Вибирати місце призначення щоразу</resource>
 		<resource name="settings_destination_printer">Роздрукувати</resource>
 		<resource name="settings_editor">Редактор</resource>
 		<resource name="settings_filenamepattern">Шаблон назви файла</resource>

--- a/src/Greenshot/Languages/language-zh-CN.xml
+++ b/src/Greenshot/Languages/language-zh-CN.xml
@@ -217,7 +217,7 @@
 		<resource name="settings_destination_email">使用E-Mail发送</resource>
 		<resource name="settings_destination_file">直接保存而不询问 （使用以下设置）</resource>
 		<resource name="settings_destination_fileas">另存到（显示对话框）</resource>
-		<resource name="settings_destination_picker">动态选择保存位置</resource>
+		<resource name="settings_destination_picker">每次选择目的地</resource>
 		<resource name="settings_destination_printer">打印图片</resource>
 		<resource name="settings_editor">编辑器</resource>
 		<resource name="settings_filenamepattern">文件名格式</resource>

--- a/src/Greenshot/Languages/language-zh-TW.xml
+++ b/src/Greenshot/Languages/language-zh-TW.xml
@@ -219,7 +219,7 @@ Greenshot 不對這個程式做任何擔保。這個程式是自由軟體，您�
 		<resource name="settings_destination_email">電子郵件</resource>
 		<resource name="settings_destination_file">直接儲存 (使用以下設定)</resource>
 		<resource name="settings_destination_fileas">另存新檔 (顯示對話方塊)</resource>
-		<resource name="settings_destination_picker">動態選取目的地</resource>
+		<resource name="settings_destination_picker">每次選取目的地</resource>
 		<resource name="settings_destination_printer">傳送到印表機</resource>
 		<resource name="settings_editor">編輯器</resource>
 		<resource name="settings_filenamepattern">檔案名稱樣式</resource>


### PR DESCRIPTION
Updated the location and size properties of several checkboxes, labels, and textboxes in the expert settings group to improve alignment and consistency in the SettingsForm.

Before
![before](https://github.com/user-attachments/assets/63bd89c9-5587-48ac-a975-ab427223f953)

After
<img width="511" height="525" alt="image" src="https://github.com/user-attachments/assets/7d247191-29b4-40a6-b516-0695bdddbb00" />
