### PR TITLE
Fix GCHandle memory leak in DibFileFormatHandler

### DIFF
--- a/src/Greenshot.Editor/FileFormatHandlers/DibFileFormatHandler.cs
+++ b/src/Greenshot.Editor/FileFormatHandlers/DibFileFormatHandler.cs
@@ -110,7 +110,7 @@ namespace Greenshot.Editor.FileFormatHandlers
             }
             finally
             {
-                if (gcHandle == IntPtr.Zero)
+                if (gcHandle != IntPtr.Zero)
                 {
                     GCHandle.FromIntPtr(gcHandle).Free();
                 }


### PR DESCRIPTION
## Summary
Fix inverted condition in `finally` block that prevents `GCHandle` from being freed.

## Change
`src/Greenshot.Editor/FileFormatHandlers/DibFileFormatHandler.cs` line 113:
- Before: `if (gcHandle == IntPtr.Zero)`
- After: `if (gcHandle != IntPtr.Zero)`

## Problem
The condition was inverted, causing:
- Handle never freed when valid (memory leak)
- Attempted free when null (no-op)

## Impact
Memory leak on every DIBV5 clipboard paste operation.