### PR TITLE
Remove deprecated TLS 1.0/1.1 protocols

### DIFF
--- a/src/Greenshot/GreenshotMain.cs
+++ b/src/Greenshot/GreenshotMain.cs
@@ -59,8 +59,8 @@ namespace Greenshot
         [STAThread]
         public static void Main(string[] args)
         {
-            // Enable TLS 1.2 support
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            // Enable TLS 1.2 and 1.3 support only (TLS 1.0/1.1 deprecated per RFC 8996)
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
 
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;


### PR DESCRIPTION
# Remove deprecated TLS 1.0/1.1 protocols

## Description
Removes support for deprecated TLS 1.0 and TLS 1.1 protocols per [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996.html), which officially deprecated these protocols in March 2021.

## Changes
**File**: `src/Greenshot/GreenshotMain.cs`

**Before:**
```csharp
// Enable TLS 1.2 support
ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
```

**After:**
```csharp
// Enable TLS 1.2 and 1.3 support only (TLS 1.0/1.1 deprecated per RFC 8996)
ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
```

## Security Rationale
- RFC 8996
- Modern services require TLS 1.2 minimum already (web browsers, cloud services (Imgur, Dropbox, etc))

## Compatibility
- **TLS 1.2**: Supported on Windows 7 SP1+ (with updates), Windows 8.1+ (natively)
- **TLS 1.3**: Supported on Windows 10 1903+ with .NET Framework 4.8