### PR TITLE
Amend setup.iss to-fall inline with standard practices

### DIFF
--- a/installer/innosetup/setup.iss
+++ b/installer/innosetup/setup.iss
@@ -156,7 +156,7 @@ WizardImageFile=installer-large.bmp
 ; Reference a bitmap, max size 55x58
 WizardSmallImageFile=installer-small.bmp
 WizardStyle=modern
-UninstallDisplayName={#ExeName} {#Version}
+UninstallDisplayName={#ExeName}
 
 [Registry]
 ; Delete all startup entries, so we don't have leftover values


### PR DESCRIPTION
Updated the Inno Setup script to exclude the application version from the uninstall display name, showing only the executable name.

The version information is already stored in DisplayVersion (set by Inno Setup's AppVersion directive), so administrators and tools can still query the installed version when needed.