### PR TITLE
[Fix] open older .greenshot files with StepLabels

### DIFF
--- a/src/Greenshot.Editor/Drawing/Fields/AbstractFieldHolder.cs
+++ b/src/Greenshot.Editor/Drawing/Fields/AbstractFieldHolder.cs
@@ -39,7 +39,7 @@ namespace Greenshot.Editor.Drawing.Fields
     {
         private static readonly ILog LOG = LogManager.GetLogger(typeof(AbstractFieldHolder));
         private static readonly EditorConfiguration EditorConfig = IniConfig.GetIniSection<EditorConfiguration>();
-        [NonSerialized] private readonly IDictionary<IField, PropertyChangedEventHandler> _handlers = new Dictionary<IField, PropertyChangedEventHandler>();
+        [NonSerialized] private IDictionary<IField, PropertyChangedEventHandler> _handlers = new Dictionary<IField, PropertyChangedEventHandler>();
 
         /// <summary>
         /// called when a field's value has changed
@@ -60,6 +60,8 @@ namespace Greenshot.Editor.Drawing.Fields
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context)
         {
+            _handlers = new Dictionary<IField, PropertyChangedEventHandler>();
+
             _fieldsByType = new Dictionary<IFieldType, IField>();
             // listen to changing properties
             foreach (var field in fields)

--- a/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
+++ b/src/Greenshot.Editor/Drawing/StepLabelContainer.cs
@@ -93,6 +93,20 @@ namespace Greenshot.Editor.Drawing
                 Alignment = StringAlignment.Center,
                 LineAlignment = StringAlignment.Center
             };
+
+            // Fix old data where thickness and shadow were not set (backwards compatibility)
+            if (!HasField(FieldType.LINE_THICKNESS))
+            {
+                AddField(GetType(), FieldType.LINE_THICKNESS, 0);
+                // aktively set because AddField above uses 0 as default but overrides it with current value from config file
+                SetFieldValue(FieldType.LINE_THICKNESS, 0);
+            }
+            if (!HasField(FieldType.SHADOW))
+            {
+                AddField(GetType(), FieldType.SHADOW, false);
+                // aktively set because AddField above uses false as default but overrides it with current value from config file
+                SetFieldValue(FieldType.SHADOW, false);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
If you open an old .greenshot file with `StepLabels` you get an exception because the fields `SHADOW` and `LINE_THICKNESS` are missing.
I added them now while deserialization.

I had to fix `AbstractFieldHolder` as well because it was not fully initialized after deserialization.

And i ran into an edge case. `AddField()` uses the given value only as a default. If a different value is specified in the greenshot.ini file, that value will be used instead. The result was that after opening old files, the step labels could always look different than the time before. 
Because of this i had to set the value actively again.