### PR TITLE
Improved cursor capture logic to reflect real size

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Greenshot.Base/Core/Capture.cs
+++ b/src/Greenshot.Base/Core/Capture.cs
@@ -102,18 +102,18 @@ namespace Greenshot.Base.Core
             _image = null;
         }
 
-        private Icon _cursor;
+        private Bitmap _cursor;
 
         /// <summary>
         /// Get/Set the image for the Cursor
         /// </summary>
-        public Icon Cursor
+        public Bitmap Cursor
         {
             get => _cursor;
             set
             {
                 _cursor?.Dispose();
-                _cursor = (Icon) value.Clone();
+                _cursor = (Bitmap) value.Clone();
             }
         }
 

--- a/src/Greenshot.Base/Greenshot.Base.csproj
+++ b/src/Greenshot.Base/Greenshot.Base.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapplo.HttpExtensions.JsonNet" Version="2.0.8" />
-    <PackageReference Include="Dapplo.Windows.Clipboard" Version="2.0.4" />
-    <PackageReference Include="Dapplo.Windows.Dpi" Version="2.0.4" />
-    <PackageReference Include="Dapplo.Windows.Gdi32" Version="2.0.4" />
-    <PackageReference Include="Dapplo.Windows.Icons" Version="2.0.4" />
-    <PackageReference Include="Dapplo.Windows.Kernel32" Version="2.0.4" />
-    <PackageReference Include="Dapplo.Windows.Multimedia" Version="2.0.4" />
+    <PackageReference Include="Dapplo.HttpExtensions.JsonNet" Version="2.0.10" />
+    <PackageReference Include="Dapplo.Windows.Clipboard" Version="2.0.7" />
+    <PackageReference Include="Dapplo.Windows.Dpi" Version="2.0.7" />
+    <PackageReference Include="Dapplo.Windows.Gdi32" Version="2.0.7" />
+    <PackageReference Include="Dapplo.Windows.Icons" Version="2.0.7" />
+    <PackageReference Include="Dapplo.Windows.Kernel32" Version="2.0.7" />
+    <PackageReference Include="Dapplo.Windows.Multimedia" Version="2.0.7" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="log4net" version="3.2.0" />
     <PackageReference Include="Svg" Version="3.4.7" />

--- a/src/Greenshot.Base/Interfaces/ICapture.cs
+++ b/src/Greenshot.Base/Interfaces/ICapture.cs
@@ -51,9 +51,9 @@ namespace Greenshot.Base.Interfaces
         NativeRect ScreenBounds { get; set; }
 
         /// <summary>
-        /// The cursor
+        /// The cursor bitmap
         /// </summary>
-        Icon Cursor { get; set; }
+        Bitmap Cursor { get; set; }
 
         /// <summary>
         /// Boolean to specify if the cursor is available

--- a/src/Greenshot.BuildTasks/Greenshot.BuildTasks.csproj
+++ b/src/Greenshot.BuildTasks/Greenshot.BuildTasks.csproj
@@ -3,9 +3,10 @@
     <DefineConstants>$(DefineConstants);GREENSHOT_BUILDTASKS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" version="17.3.2">
+    <PackageReference Include="Microsoft.Build.Utilities.Core" version="18.0.2">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />   
     <PackageReference Include="SixLabors.ImageSharp.Drawing" version="1.0.0" />

--- a/src/Greenshot.Editor/Drawing/Surface.cs
+++ b/src/Greenshot.Editor/Drawing/Surface.cs
@@ -550,7 +550,7 @@ namespace Greenshot.Editor.Drawing
                 // check if cursor is on the capture, otherwise we leave it out.
                 if (cursorRect.IntersectsWith(captureRect))
                 {
-                    _cursorContainer = AddIconContainer(capture.Cursor, capture.CursorLocation.X, capture.CursorLocation.Y);
+                    _cursorContainer = AddImageContainer(capture.Cursor, capture.CursorLocation.X, capture.CursorLocation.Y);
                     SelectElement(_cursorContainer);
                 }
             }

--- a/src/Greenshot/Forms/CaptureForm.cs
+++ b/src/Greenshot/Forms/CaptureForm.cs
@@ -1008,7 +1008,7 @@ namespace Greenshot.Forms
             // Only draw Cursor if it's (partly) visible
             if (_capture.Cursor != null && _capture.CursorVisible && clipRectangle.IntersectsWith(new NativeRect(_capture.CursorLocation, _capture.Cursor.Size)))
             {
-                graphics.DrawIcon(_capture.Cursor, _capture.CursorLocation.X, _capture.CursorLocation.Y);
+                graphics.DrawImageUnscaled(_capture.Cursor, _capture.CursorLocation.X, _capture.CursorLocation.Y);
             }
 
             if (_mouseDown || _captureMode == CaptureMode.Window || IsAnimating(_windowAnimator))


### PR DESCRIPTION
Improved the way we take the mouse cursor for the capture. Before the cursor was the small default one, now we look at the settings and take the size as the user has configured. This was a long standing issue...

In fact, I was reminded of this due to a google notification, which was trigged due to this here: https://www.computerbase.de/forum/threads/screenshot-von-genau-dem-was-man-auf-sieht-inkl-korrekter-cursor-groesse.2264060/

Now it should be fixed, this is before my change (my mouse cursor was set to HUGE):
<img width="993" height="167" alt="image" src="https://github.com/user-attachments/assets/6a02e8be-aa62-42d6-ac9c-7007b707d4c2" />

And this after, which makes it look exactly like it was on the screen: 
<img width="995" height="223" alt="image" src="https://github.com/user-attachments/assets/3ff1f88a-34b8-4a9b-8829-3661684a3365" />
