### PR TITLE
Fix pointer conversion for bitmap data

### DIFF
--- a/src/Greenshot.Base/Core/ClipboardHelper.cs
+++ b/src/Greenshot.Base/Core/ClipboardHelper.cs
@@ -1141,7 +1141,7 @@ EndSelection:<<<<<<<4
 
             int absStride = Math.Abs(bmpData.Stride);
             int bytes = absStride * bitmap.Height;
-            long ptr = bmpData.Scan0.ToInt32();
+            long ptr = bmpData.Scan0.ToInt64();
             // Declare an array to hold the bytes of the bitmap.
             byte[] rgbValues = new byte[bytes];
 


### PR DESCRIPTION
Changed Scan0 pointer conversion from ToInt32() to ToInt64() to correctly handle 64-bit environments and prevent potential data loss or errors when working with bitmap data.