### PR TITLE
Fix null reference in cursor setter

### DIFF
--- a/src/Greenshot.Base/Core/Capture.cs
+++ b/src/Greenshot.Base/Core/Capture.cs
@@ -113,7 +113,7 @@ namespace Greenshot.Base.Core
             set
             {
                 _cursor?.Dispose();
-                _cursor = (Bitmap) value.Clone();
+                _cursor = (Bitmap) value?.Clone();
             }
         }
 


### PR DESCRIPTION
The Cursor property setter in Capture.cs would throw a NullReferenceException if null was assigned to it. The code called value.Clone() without checking if value was null first.

I ahve added a null-conditional operator (value?.Clone()) to safely handle null assignments. When null is passed, the cursor is now properly set to null instead of crashing.