### PR TITLE
Dispose zoom matrices to prevent GDI handle leaks

### DIFF
--- a/src/Greenshot.Editor/Drawing/Surface.cs
+++ b/src/Greenshot.Editor/Drawing/Surface.cs
@@ -350,6 +350,11 @@ namespace Greenshot.Editor.Drawing
             {
                 _zoomFactor = value;
                 var inverse = _zoomFactor.Inverse();
+
+                // Dispose old matrices before creating new ones to prevent GDI handle leaks
+                _zoomMatrix?.Dispose();
+                _inverseZoomMatrix?.Dispose();
+
                 _zoomMatrix = new Matrix(_zoomFactor, 0, 0, _zoomFactor, 0, 0);
                 _inverseZoomMatrix = new Matrix(inverse, 0, 0, inverse, 0, 0);
                 UpdateSize();
@@ -576,6 +581,19 @@ namespace Greenshot.Editor.Drawing
                 {
                     _transparencyBackgroundBrush.Dispose();
                     _transparencyBackgroundBrush = null;
+                }
+
+                // Dispose zoom matrices to release GDI handles
+                if (_zoomMatrix != null)
+                {
+                    _zoomMatrix.Dispose();
+                    _zoomMatrix = null;
+                }
+
+                if (_inverseZoomMatrix != null)
+                {
+                    _inverseZoomMatrix.Dispose();
+                    _inverseZoomMatrix = null;
                 }
 
                 // Cleanup undo/redo stacks


### PR DESCRIPTION
The Surface class uses two Matrix objects (_zoomMatrix and _inverseZoomMatrix) for zoom transformations.

System.Drawing.Drawing2D.Matrix implements IDisposable and holds unmanaged GDI handles, but:

When ZoomFactor was set, new Matrix objects were created without disposing the old ones The matrices were never disposed when the Surface was disposed

This caused GDI handle leaks every time the user changed the zoom level, which could eventually exhaust the system's GDI handle limit.

Added disposal of old matrices in the ZoomFactor setter before creating new ones

Added disposal of matrices in the Dispose method