### PR TITLE
Dispose unused file streams in ClipboardHelper

### DIFF
--- a/src/Greenshot.Base/Core/ClipboardHelper.cs
+++ b/src/Greenshot.Base/Core/ClipboardHelper.cs
@@ -447,16 +447,21 @@ EndSelection:<<<<<<<4
                 try
                 {
                     fileData = FileDescriptorReader.GetFileContents(dataObject, fileIndex);
-                    //Do something with the fileContent Stream
                 }
                 catch (Exception ex)
                 {
                     Log.Error($"Couldn't read file contents for {fileDescriptor.FileName}.", ex);
                 }
+
                 if (fileData?.Length > 0)
                 {
                     fileData.Position = 0;
                     yield return (fileData, fileDescriptor.FileName);
+                }
+                else
+                {
+                    // Dispose the stream if it won't be yielded (empty or null length)
+                    fileData?.Dispose();
                 }
 
                 fileIndex++;


### PR DESCRIPTION
In ClipboardHelper.IterateFileDescriptors(), a MemoryStream is created for each file descriptor, but it was only yielded to the caller when fileData?.Length > 0. In cases where:

The stream was created but had zero length
The stream was created but an exception occurred during content reading The MemoryStream was never disposed, causing a memory leak.

Added an else branch to dispose the MemoryStream when it won't be yielded to the caller (i.e., when it's empty or has zero length).