### PR TITLE
Refactor clipboard retry logic in ClipboardHelper

### DIFF
--- a/src/Greenshot.Base/Core/ClipboardHelper.cs
+++ b/src/Greenshot.Base/Core/ClipboardHelper.cs
@@ -208,8 +208,8 @@ EndSelection:<<<<<<<4
         {
             lock (ClipboardLockObject)
             {
-                int retryCount = 2;
-                while (retryCount >= 0)
+                const int maxRetries = 3;
+                for (int attempt = 0; attempt < maxRetries; attempt++)
                 {
                     try
                     {
@@ -217,7 +217,8 @@ EndSelection:<<<<<<<4
                     }
                     catch (Exception ee)
                     {
-                        if (retryCount == 0)
+                        bool isLastAttempt = attempt == maxRetries - 1;
+                        if (isLastAttempt)
                         {
                             string messageText;
                             string clipboardOwner = GetClipboardOwner();
@@ -236,10 +237,6 @@ EndSelection:<<<<<<<4
                         {
                             Thread.Sleep(100);
                         }
-                    }
-                    finally
-                    {
-                        --retryCount;
                     }
                 }
             }


### PR DESCRIPTION
The GetDataObject() retry loop had a logic flaw where retryCount was decremented in a finally block, which executes on both success and failure. This meant:

On success, the counter was unnecessarily decremented before returning The loop structure was confusing - using while (retryCount >= 0) with a decrement in finally made it hard to understand the actual retry count.

Refactored to use a cleaner for loop pattern:

Clear maxRetries constant (3 attempts total)
Loop counter only advances on each iteration (not in finally) isLastAttempt boolean makes the intent clear
Same functional behavior (3 attempts with 100ms delay between failures)