### PR TITLE
Restore bitmap lock state after drawing

### DIFF
--- a/src/Greenshot.Base/Core/FastBitmap.cs
+++ b/src/Greenshot.Base/Core/FastBitmap.cs
@@ -616,6 +616,12 @@ namespace Greenshot.Base.Core
             }
 
             graphics.DrawImage(Bitmap, destinationRect, Area, GraphicsUnit.Pixel);
+
+            // Re-lock if it was locked before
+            if (isLocked)
+            {
+                Lock();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Ensures that the bitmap is re-locked after drawing if it was previously locked, preserving the original lock state.

The DrawTo method in FastBitmap.cs temporarily unlocks the bitmap to perform a draw operation, but never re-locks it afterward. This causes unexpected state changes where callers may rely on the bitmap remaining locked after the call.

Added re-locking logic after DrawImage completes - if the bitmap was locked before the call, it is now locked again after the draw operation.

This preserves lock state consistency for callers of DrawTo, preventing potential issues with subsequent operations that expect the bitmap to remain in its original locked state.