### PR TITLE
Use 'using' statements for GDI+ resources in CaptureForm

### DIFF
--- a/src/Greenshot/Forms/CaptureForm.cs
+++ b/src/Greenshot/Forms/CaptureForm.cs
@@ -1062,8 +1062,8 @@ namespace Greenshot.Forms
                     Size measureHeight = TextRenderer.MeasureText(captureHeight, rulerFont);
                     int hSpace = measureWidth.Width + 3;
                     int vSpace = measureHeight.Height + 3;
-                    Brush bgBrush = new SolidBrush(Color.FromArgb(200, 217, 240, 227));
-                    Pen rulerPen = new Pen(Color.SeaGreen);
+                    using Brush bgBrush = new SolidBrush(Color.FromArgb(200, 217, 240, 227));
+                    using Pen rulerPen = new Pen(Color.SeaGreen);
 
                     // horizontal ruler
                     if (fixedRect.Width > hSpace + 3)
@@ -1100,9 +1100,6 @@ namespace Greenshot.Forms
                         graphics.DrawLine(rulerPen, fixedRect.X - dist - 3, fixedRect.Y, fixedRect.X - dist + 3, fixedRect.Y);
                         graphics.DrawLine(rulerPen, fixedRect.X - dist - 3, fixedRect.Y + fixedRect.Height, fixedRect.X - dist + 3, fixedRect.Y + fixedRect.Height);
                     }
-
-                    rulerPen.Dispose();
-                    bgBrush.Dispose();
                 }
 
                 // Display size of selected rectangle


### PR DESCRIPTION
Problem: In the OnPaint method, bgBrush and rulerPen are created without using statements and disposed manually at the end of the block. If an exception occurs between creation and disposal, these GDI resources will leak.

Solution: Changed bgBrush and rulerPen declarations to use using statements, ensuring proper disposal even if an exception occurs. Removed the now-redundant manual .Dispose() calls.

Impact: Ensures GDI resources are properly disposed in all code paths, preventing potential resource leaks during exception scenarios in the paint handler.