### PR TITLE
Dispose capture object in Dispose method

### DIFF
--- a/src/Greenshot/Helpers/CaptureHelper.cs
+++ b/src/Greenshot/Helpers/CaptureHelper.cs
@@ -83,10 +83,10 @@ namespace Greenshot.Helpers
         {
             if (disposing)
             {
-                // Cleanup
+                // Dispose the capture if it hasn't been disposed in another code path
+                _capture?.Dispose();
             }
 
-            // Unfortunately we can't dispose the capture, this might still be used somewhere else.
             _windows = null;
             _selectedCaptureWindow = null;
             _capture = null;


### PR DESCRIPTION
The Dispose(bool) method in CaptureHelper sets _capture = null without disposing it first. While some code paths dispose _capture explicitly (e.g., after successful capture), other paths - notably when user cancels the capture via CaptureWithFeedback() - leave _capture undisposed, causing an image memory leak.

Added _capture?.Dispose() in the Dispose(bool) method to ensure the capture is always disposed when the CaptureHelper is disposed. Since ICapture.Dispose() is idempotent (safe to call multiple times), this won't cause issues in code paths that already dispose the capture.

Prevents memory leaks when users cancel captures, ensuring the captured image is properly released in all scenarios.