### PR TITLE
Handle exceptions during cursor capture

### DIFF
--- a/src/Greenshot.Base/Core/WindowCapture.cs
+++ b/src/Greenshot.Base/Core/WindowCapture.cs
@@ -86,17 +86,24 @@ namespace Greenshot.Base.Core
                 capture = new Capture();
             }
 
-            Bitmap cursorBitmap;
-            NativePoint cursorHotSpot;
-            if (CursorHelper.TryGetCurrentCursor(out cursorBitmap, out cursorHotSpot))
+            try
             {
-                NativePoint cursorLocation = User32Api.GetCursorLocation();
-                // Align cursor location to Bitmap coordinates (instead of Screen coordinates)
-                var x = cursorLocation.X - cursorHotSpot.X - capture.ScreenBounds.X;
-                var y = cursorLocation.Y - cursorHotSpot.Y - capture.ScreenBounds.Y;
-                // Set the location
-                capture.CursorLocation = new NativePoint(x, y);
-                capture.Cursor = cursorBitmap;
+                Bitmap cursorBitmap;
+                NativePoint cursorHotSpot;
+                if (CursorHelper.TryGetCurrentCursor(out cursorBitmap, out cursorHotSpot))
+                {
+                    NativePoint cursorLocation = User32Api.GetCursorLocation();
+                    // Align cursor location to Bitmap coordinates (instead of Screen coordinates)
+                    var x = cursorLocation.X - cursorHotSpot.X - capture.ScreenBounds.X;
+                    var y = cursorLocation.Y - cursorHotSpot.Y - capture.ScreenBounds.Y;
+                    // Set the location
+                    capture.CursorLocation = new NativePoint(x, y);
+                    capture.Cursor = cursorBitmap;
+                }
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                Log.Warn("Failed to capture cursor, proceeding without cursor.", ex);
             }
             return capture;
         }


### PR DESCRIPTION
I had a good 10+ of these errors today so have created this to be reviewed which should sort the issue. I use a green cursor at work for vision and i suspect this is possibly the reason why.

Software version: 1.4.68 - 1cb951119f (64 bit)
.NET runtime version: 4.0.30319.42000+
Time: 2026-01-28 08:08:45 +00:00
OS: Windows 11 x64 build 26100
GDI object count: 60
User object count: 23
Exception: System.ComponentModel.Win32Exception
Message: Invalid cursor handle
ErrorCode: 0x80004005
Stack:
   at Dapplo.Windows.Icons.CursorHelper.TryGetCurrentCursor[TBitmapType](TBitmapType& returnBitmap, NativePoint& hotSpot)
   at Greenshot.Base.Core.WindowCapture.CaptureCursor(ICapture capture)
   at Greenshot.Helpers.CaptureHelper.MakeCapture()
   at Greenshot.Helpers.CaptureHelper.CaptureRegion(Boolean captureMouse)
   at Greenshot.Base.Controls.HotkeyControl.HandleMessages(Message& m)
   at Greenshot.Forms.MainForm.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
Configuration dump:

Wrapped the cursor capture logic in a try-catch block to handle potential Win32Exceptions. If capturing the cursor fails, a warning is logged and the capture proceeds without the cursor, improving robustness.