### PR TITLE
[Fix] destination picker

### DIFF
--- a/src/Greenshot.Base/Core/AbstractDestination.cs
+++ b/src/Greenshot.Base/Core/AbstractDestination.cs
@@ -183,8 +183,6 @@ namespace Greenshot.Base.Core
                 TopLevel = true
             };
 
-            menu.SetupAutoDispose();
-
             menu.Opening += (sender, args) =>
             {
                 // find the DPI settings for the screen where this is going to land
@@ -211,6 +209,7 @@ namespace Greenshot.Base.Core
                         else
                         {
                             Log.DebugFormat("Letting the menu 'close' as the tag is set to '{0}'", menu.Tag);
+                            menu.Dispose();
                         }
 
                         break;
@@ -219,13 +218,13 @@ namespace Greenshot.Base.Core
                         // The ContextMenuStrip can be "closed" for these reasons.
                         break;
                     case ToolStripDropDownCloseReason.Keyboard:
-                        // Dispose as the close is clicked
+                        // Menu closed via keyboard (e.g., ESC key)
                         if (!captureDetails.HasDestination("Editor"))
                         {
                             surface.Dispose();
                             surface = null;
                         }
-
+                        menu.Dispose();
                         break;
                     default:
                         eventArgs.Cancel = true;
@@ -261,7 +260,7 @@ namespace Greenshot.Base.Core
                             Log.InfoFormat("Export to {0} success, closing menu", exportInformation.DestinationDescription);
                             // close menu if the destination wasn't the editor
                             menu.Close();
-
+                            menu.Dispose();
                             // Cleanup surface, only if there is no editor in the destinations and we didn't export to the editor
                             if (!captureDetails.HasDestination("Editor") && !"Editor".Equals(clickedDestination.Designation))
                             {
@@ -297,6 +296,7 @@ namespace Greenshot.Base.Core
             {
                 // This menu entry is the close itself, we can dispose the surface
                 menu.Close();
+                menu.Dispose();
                 if (!captureDetails.HasDestination("Editor"))
                 {
                     surface.Dispose();

--- a/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
@@ -25,7 +25,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
-using System.Threading;
 using System.Windows.Forms;
 using Dapplo.Windows.Common.Extensions;
 using Dapplo.Windows.Common.Structs;
@@ -730,7 +729,11 @@ namespace Greenshot.Editor.Drawing
             ContextMenuStrip menu = new ContextMenuStrip();
             menu.SetupAutoDispose();
             AddContextMenuItems(menu, surface, mouseEventArgs);
-            if (menu.Items.Count <= 0) return;
+            if (menu.Items.Count <= 0)
+            {
+                menu.Dispose();
+                return;
+            }
             menu.Show(surface, surface.ToSurfaceCoordinates(mouseEventArgs.Location));
         }
 


### PR DESCRIPTION
The destination picker menu was disposed too early. 
If an export was canceled, the menu could not be reopened.