### PR TITLE
Simple group box / label extend

### DIFF
--- a/src/Greenshot.Editor/Forms/DropShadowSettingsForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/DropShadowSettingsForm.Designer.cs
@@ -110,7 +110,7 @@ namespace Greenshot.Editor.Forms {
 			// 
 			this.label3.Location = new System.Drawing.Point(153, 35);
 			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(14, 13);
+			this.label3.Size = new System.Drawing.Size(14, 20);
 			this.label3.TabIndex = 5;
 			this.label3.Text = "X";
 			// 
@@ -171,7 +171,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelDarkness.LanguageKey = "editor_dropshadow_darkness";
 			this.labelDarkness.Location = new System.Drawing.Point(12, 73);
 			this.labelDarkness.Name = "labelDarkness";
-			this.labelDarkness.Size = new System.Drawing.Size(92, 13);
+			this.labelDarkness.Size = new System.Drawing.Size(92, 20);
 			this.labelDarkness.TabIndex = 13;
 			// 
 			// labelOffset
@@ -179,7 +179,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelOffset.LanguageKey = "editor_dropshadow_offset";
 			this.labelOffset.Location = new System.Drawing.Point(12, 35);
 			this.labelOffset.Name = "labelOffset";
-			this.labelOffset.Size = new System.Drawing.Size(75, 13);
+			this.labelOffset.Size = new System.Drawing.Size(85, 20);
 			this.labelOffset.TabIndex = 14;
 			// 
 			// labelThickness
@@ -187,7 +187,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelThickness.LanguageKey = "editor_dropshadow_thickness";
 			this.labelThickness.Location = new System.Drawing.Point(12, 9);
 			this.labelThickness.Name = "labelThickness";
-			this.labelThickness.Size = new System.Drawing.Size(94, 13);
+			this.labelThickness.Size = new System.Drawing.Size(155, 20);
 			this.labelThickness.TabIndex = 15;
 			// 
 			// DropShadowSettingsForm

--- a/src/Greenshot.Editor/Forms/ResizeSettingsForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/ResizeSettingsForm.Designer.cs
@@ -82,7 +82,7 @@ namespace Greenshot.Editor.Forms {
 			this.checkbox_aspectratio.LanguageKey = "editor_resize_aspectratio";
 			this.checkbox_aspectratio.Location = new System.Drawing.Point(22, 64);
 			this.checkbox_aspectratio.Name = "checkbox_aspectratio";
-			this.checkbox_aspectratio.Size = new System.Drawing.Size(124, 17);
+			this.checkbox_aspectratio.Size = new System.Drawing.Size(210, 20);
 			this.checkbox_aspectratio.TabIndex = 5;
 			this.checkbox_aspectratio.UseVisualStyleBackColor = true;
 			// 
@@ -91,7 +91,7 @@ namespace Greenshot.Editor.Forms {
 			this.label_width.LanguageKey = "editor_resize_width";
 			this.label_width.Location = new System.Drawing.Point(19, 15);
 			this.label_width.Name = "label_width";
-			this.label_width.Size = new System.Drawing.Size(35, 13);
+			this.label_width.Size = new System.Drawing.Size(65, 20);
 			this.label_width.TabIndex = 14;
 			// 
 			// label_height
@@ -99,7 +99,7 @@ namespace Greenshot.Editor.Forms {
 			this.label_height.LanguageKey = "editor_resize_height";
 			this.label_height.Location = new System.Drawing.Point(19, 38);
 			this.label_height.Name = "label_height";
-			this.label_height.Size = new System.Drawing.Size(38, 13);
+			this.label_height.Size = new System.Drawing.Size(65, 20);
 			this.label_height.TabIndex = 15;
 			// 
 			// textbox_height

--- a/src/Greenshot.Editor/Forms/TornEdgeSettingsForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/TornEdgeSettingsForm.Designer.cs
@@ -125,7 +125,7 @@ namespace Greenshot.Editor.Forms {
 			// 
 			this.label3.Location = new System.Drawing.Point(153, 63);
 			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(12, 13);
+			this.label3.Size = new System.Drawing.Size(12, 20);
 			this.label3.TabIndex = 5;
 			this.label3.Text = "x";
 			// 
@@ -186,7 +186,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelDarkness.LanguageKey = "editor_dropshadow_darkness";
 			this.labelDarkness.Location = new System.Drawing.Point(12, 97);
 			this.labelDarkness.Name = "labelDarkness";
-			this.labelDarkness.Size = new System.Drawing.Size(92, 13);
+			this.labelDarkness.Size = new System.Drawing.Size(155, 20);
 			this.labelDarkness.TabIndex = 13;
 			this.labelDarkness.Text = "Shadow darkness";
 			// 
@@ -195,7 +195,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelOffset.LanguageKey = "editor_dropshadow_offset";
 			this.labelOffset.Location = new System.Drawing.Point(12, 63);
 			this.labelOffset.Name = "labelOffset";
-			this.labelOffset.Size = new System.Drawing.Size(75, 13);
+			this.labelOffset.Size = new System.Drawing.Size(85, 20);
 			this.labelOffset.TabIndex = 14;
 			// 
 			// labelThickness
@@ -203,7 +203,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelThickness.LanguageKey = "editor_dropshadow_thickness";
 			this.labelThickness.Location = new System.Drawing.Point(12, 37);
 			this.labelThickness.Name = "labelThickness";
-			this.labelThickness.Size = new System.Drawing.Size(94, 13);
+			this.labelThickness.Size = new System.Drawing.Size(155, 20);
 			this.labelThickness.TabIndex = 15;
 			// 
 			// toothsize
@@ -233,7 +233,7 @@ namespace Greenshot.Editor.Forms {
 			this.label_toothsize.LanguageKey = "editor_tornedge_toothsize";
 			this.label_toothsize.Location = new System.Drawing.Point(12, 140);
 			this.label_toothsize.Name = "label_toothsize";
-			this.label_toothsize.Size = new System.Drawing.Size(56, 13);
+			this.label_toothsize.Size = new System.Drawing.Size(155, 20);
 			this.label_toothsize.TabIndex = 17;
 			// 
 			// label_horizontaltoothrange
@@ -241,7 +241,7 @@ namespace Greenshot.Editor.Forms {
 			this.label_horizontaltoothrange.LanguageKey = "editor_tornedge_horizontaltoothrange";
 			this.label_horizontaltoothrange.Location = new System.Drawing.Point(12, 166);
 			this.label_horizontaltoothrange.Name = "label_horizontaltoothrange";
-			this.label_horizontaltoothrange.Size = new System.Drawing.Size(111, 13);
+			this.label_horizontaltoothrange.Size = new System.Drawing.Size(155, 20);
 			this.label_horizontaltoothrange.TabIndex = 19;			// 
 			// horizontaltoothrange
 			// 
@@ -270,7 +270,7 @@ namespace Greenshot.Editor.Forms {
 			this.labelVerticaltoothrange.LanguageKey = "editor_tornedge_verticaltoothrange";
 			this.labelVerticaltoothrange.Location = new System.Drawing.Point(12, 192);
 			this.labelVerticaltoothrange.Name = "labelVerticaltoothrange";
-			this.labelVerticaltoothrange.Size = new System.Drawing.Size(99, 13);
+			this.labelVerticaltoothrange.Size = new System.Drawing.Size(155, 20);
 			this.labelVerticaltoothrange.TabIndex = 21;
 			// 
 			// verticaltoothrange
@@ -347,7 +347,7 @@ namespace Greenshot.Editor.Forms {
 			this.shadowCheckbox.LanguageKey = "editor_tornedge_shadow";
 			this.shadowCheckbox.Location = new System.Drawing.Point(12, 12);
 			this.shadowCheckbox.Name = "shadowCheckbox";
-			this.shadowCheckbox.Size = new System.Drawing.Size(110, 17);
+			this.shadowCheckbox.Size = new System.Drawing.Size(225, 20);
 			this.shadowCheckbox.TabIndex = 1;
 			this.shadowCheckbox.UseVisualStyleBackColor = true;
 			this.shadowCheckbox.CheckedChanged += new System.EventHandler(this.ShadowCheckbox_CheckedChanged);
@@ -357,7 +357,7 @@ namespace Greenshot.Editor.Forms {
 			this.all.LanguageKey = "editor_tornedge_all";
 			this.all.Location = new System.Drawing.Point(251, 12);
 			this.all.Name = "all";
-			this.all.Size = new System.Drawing.Size(88, 17);
+			this.all.Size = new System.Drawing.Size(230, 20);
 			this.all.TabIndex = 9;
 			this.all.UseVisualStyleBackColor = true;
 			this.all.CheckedChanged += new System.EventHandler(this.all_CheckedChanged);

--- a/src/Greenshot.Plugin.Box/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.Box/Forms/SettingsForm.Designer.cs
@@ -106,7 +106,7 @@ namespace Greenshot.Plugin.Box.Forms {
 			this.label_AfterUpload.LanguageKey = "box.label_AfterUpload";
 			this.label_AfterUpload.Location = new System.Drawing.Point(10, 46);
 			this.label_AfterUpload.Name = "label_AfterUpload";
-			this.label_AfterUpload.Size = new System.Drawing.Size(84, 21);
+			this.label_AfterUpload.Size = new System.Drawing.Size(192, 21);
 			this.label_AfterUpload.TabIndex = 8;
 			// 
 			// checkboxAfterUploadLinkToClipBoard
@@ -117,7 +117,7 @@ namespace Greenshot.Plugin.Box.Forms {
 			this.checkboxAfterUploadLinkToClipBoard.Name = "checkboxAfterUploadLinkToClipBoard";
 			this.checkboxAfterUploadLinkToClipBoard.PropertyName = nameof(BoxConfiguration.AfterUploadLinkToClipBoard);
 			this.checkboxAfterUploadLinkToClipBoard.SectionName = "Box";
-			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(104, 17);
+			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(210, 20);
 			this.checkboxAfterUploadLinkToClipBoard.TabIndex = 10;
 			this.checkboxAfterUploadLinkToClipBoard.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot.Plugin.Dropbox/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.Dropbox/Forms/SettingsForm.Designer.cs
@@ -96,7 +96,7 @@ namespace Greenshot.Plugin.Dropbox.Forms {
 			this.label_upload_format.LanguageKey = "dropbox.label_upload_format";
 			this.label_upload_format.Location = new System.Drawing.Point(11, 12);
 			this.label_upload_format.Name = "label_upload_format";
-			this.label_upload_format.Size = new System.Drawing.Size(84, 20);
+			this.label_upload_format.Size = new System.Drawing.Size(100, 20);
 			this.label_upload_format.TabIndex = 9;
 			// 
 			// label_AfterUpload
@@ -104,7 +104,7 @@ namespace Greenshot.Plugin.Dropbox.Forms {
 			this.label_AfterUpload.LanguageKey = "dropbox.label_AfterUpload";
 			this.label_AfterUpload.Location = new System.Drawing.Point(10, 37);
 			this.label_AfterUpload.Name = "label_AfterUpload";
-			this.label_AfterUpload.Size = new System.Drawing.Size(84, 21);
+			this.label_AfterUpload.Size = new System.Drawing.Size(100, 21);
 			this.label_AfterUpload.TabIndex = 22;
 			// 
 			// checkboxAfterUploadLinkToClipBoard
@@ -114,7 +114,7 @@ namespace Greenshot.Plugin.Dropbox.Forms {
 			this.checkboxAfterUploadLinkToClipBoard.Name = "checkboxAfterUploadLinkToClipBoard";
 			this.checkboxAfterUploadLinkToClipBoard.PropertyName = nameof(DropboxConfiguration.AfterUploadLinkToClipBoard);
 			this.checkboxAfterUploadLinkToClipBoard.SectionName = "Dropbox";
-			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(104, 17);
+			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(305, 20);
 			this.checkboxAfterUploadLinkToClipBoard.TabIndex = 2;
 			this.checkboxAfterUploadLinkToClipBoard.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot.Plugin.ExternalCommand/SettingsFormDetail.Designer.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/SettingsFormDetail.Designer.cs
@@ -133,7 +133,7 @@ namespace Greenshot.Plugin.ExternalCommand {
 			this.label3.LanguageKey = "externalcommand.label_name";
 			this.label3.Location = new System.Drawing.Point(6, 26);
 			this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(83, 17);
+            this.label3.Size = new System.Drawing.Size(83, 20);
 			this.label3.TabIndex = 17;
             this.label3.Text = "Name";
 			// 
@@ -150,7 +150,7 @@ namespace Greenshot.Plugin.ExternalCommand {
 			this.label2.LanguageKey = "externalcommand.label_argument";
 			this.label2.Location = new System.Drawing.Point(6, 78);
 			this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 17);
+            this.label2.Size = new System.Drawing.Size(83, 20);
 			this.label2.TabIndex = 16;
             this.label2.Text = "Arguments";
 			// 
@@ -167,7 +167,7 @@ namespace Greenshot.Plugin.ExternalCommand {
 			this.label1.LanguageKey = "externalcommand.label_command";
 			this.label1.Location = new System.Drawing.Point(6, 52);
 			this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(83, 17);
+            this.label1.Size = new System.Drawing.Size(83, 20);
 			this.label1.TabIndex = 15;
             this.label1.Text = "Command";
 			// 
@@ -184,7 +184,7 @@ namespace Greenshot.Plugin.ExternalCommand {
             this.label5.LanguageKey = "externalcommand.label_outputimageformat";
             this.label5.Location = new System.Drawing.Point(6, 126);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(83, 17);
+            this.label5.Size = new System.Drawing.Size(83, 20);
             this.label5.TabIndex = 18;
             this.label5.Text = "Image format";
             // 

--- a/src/Greenshot.Plugin.Flickr/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.Flickr/Forms/SettingsForm.Designer.cs
@@ -113,7 +113,7 @@ namespace Greenshot.Plugin.Flickr.Forms {
 			this.checkBoxPublic.Name = "checkBoxPublic";
 			this.checkBoxPublic.PropertyName = nameof(FlickrConfiguration.IsPublic);
 			this.checkBoxPublic.SectionName = "Flickr";
-			this.checkBoxPublic.Size = new System.Drawing.Size(55, 17);
+			this.checkBoxPublic.Size = new System.Drawing.Size(85, 20);
 			this.checkBoxPublic.TabIndex = 4;
 			this.checkBoxPublic.UseVisualStyleBackColor = true;
 			// 
@@ -124,7 +124,7 @@ namespace Greenshot.Plugin.Flickr.Forms {
 			this.checkBoxFamily.Name = "checkBoxFamily";
 			this.checkBoxFamily.PropertyName = nameof(FlickrConfiguration.IsFamily);
 			this.checkBoxFamily.SectionName = "Flickr";
-			this.checkBoxFamily.Size = new System.Drawing.Size(55, 17);
+			this.checkBoxFamily.Size = new System.Drawing.Size(80, 20);
 			this.checkBoxFamily.TabIndex = 5;
 			this.checkBoxFamily.UseVisualStyleBackColor = true;
 			// 
@@ -135,7 +135,7 @@ namespace Greenshot.Plugin.Flickr.Forms {
 			this.checkBoxFriend.Name = "checkBoxFriend";
 			this.checkBoxFriend.PropertyName = nameof(FlickrConfiguration.IsFriend);
 			this.checkBoxFriend.SectionName = "Flickr";
-			this.checkBoxFriend.Size = new System.Drawing.Size(55, 17);
+			this.checkBoxFriend.Size = new System.Drawing.Size(80, 20);
 			this.checkBoxFriend.TabIndex = 6;
 			this.checkBoxFriend.UseVisualStyleBackColor = true;
 			// 
@@ -175,7 +175,7 @@ namespace Greenshot.Plugin.Flickr.Forms {
 			this.checkboxAfterUploadLinkToClipBoard.Name = "checkboxAfterUploadLinkToClipBoard";
 			this.checkboxAfterUploadLinkToClipBoard.PropertyName = nameof(FlickrConfiguration.AfterUploadLinkToClipBoard);
 			this.checkboxAfterUploadLinkToClipBoard.SectionName = "Flickr";
-			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(104, 17);
+			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(250, 20);
 			this.checkboxAfterUploadLinkToClipBoard.TabIndex = 7;
 			this.checkboxAfterUploadLinkToClipBoard.UseVisualStyleBackColor = true;
 			// 
@@ -186,7 +186,7 @@ namespace Greenshot.Plugin.Flickr.Forms {
 			this.checkBox_hiddenfromsearch.Name = "checkBox_hiddenfromsearch";
 			this.checkBox_hiddenfromsearch.PropertyName = nameof(FlickrConfiguration.HiddenFromSearch);
 			this.checkBox_hiddenfromsearch.SectionName = "Flickr";
-			this.checkBox_hiddenfromsearch.Size = new System.Drawing.Size(118, 17);
+			this.checkBox_hiddenfromsearch.Size = new System.Drawing.Size(250, 20);
 			this.checkBox_hiddenfromsearch.TabIndex = 3;
 			this.checkBox_hiddenfromsearch.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot.Plugin.GooglePhotos/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.GooglePhotos/Forms/SettingsForm.Designer.cs
@@ -116,7 +116,7 @@ namespace Greenshot.Plugin.GooglePhotos.Forms {
 			this.checkboxAfterUploadLinkToClipBoard.Name = "checkboxAfterUploadLinkToClipBoard";
 			this.checkboxAfterUploadLinkToClipBoard.PropertyName = nameof(GooglePhotosConfiguration.AfterUploadLinkToClipBoard);
 			this.checkboxAfterUploadLinkToClipBoard.SectionName = "GooglePhotos";
-			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(104, 17);
+			this.checkboxAfterUploadLinkToClipBoard.Size = new System.Drawing.Size(225, 20);
 			this.checkboxAfterUploadLinkToClipBoard.TabIndex = 2;
 			this.checkboxAfterUploadLinkToClipBoard.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot.Plugin.Imgur/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.Imgur/Forms/SettingsForm.Designer.cs
@@ -117,7 +117,7 @@ namespace Greenshot.Plugin.Imgur.Forms {
 			this.checkbox_anonymous_access.Name = "checkbox_anonymous_access";
 			this.checkbox_anonymous_access.PropertyName = nameof(ImgurConfiguration.AnonymousAccess);
 			this.checkbox_anonymous_access.SectionName = "Imgur";
-			this.checkbox_anonymous_access.Size = new System.Drawing.Size(139, 17);
+			this.checkbox_anonymous_access.Size = new System.Drawing.Size(360, 20);
 			this.checkbox_anonymous_access.TabIndex = 2;
 			this.checkbox_anonymous_access.UseVisualStyleBackColor = true;
 			// 
@@ -128,7 +128,7 @@ namespace Greenshot.Plugin.Imgur.Forms {
 			this.checkbox_usepagelink.Name = "checkbox_usepagelink";
 			this.checkbox_usepagelink.PropertyName = nameof(ImgurConfiguration.UsePageLink);
 			this.checkbox_usepagelink.SectionName = "Imgur";
-			this.checkbox_usepagelink.Size = new System.Drawing.Size(251, 17);
+			this.checkbox_usepagelink.Size = new System.Drawing.Size(360, 20);
 			this.checkbox_usepagelink.TabIndex = 3;
 			this.checkbox_usepagelink.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot.Plugin.Photobucket/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot.Plugin.Photobucket/Forms/SettingsForm.Designer.cs
@@ -94,7 +94,7 @@ namespace Greenshot.Plugin.Photobucket.Forms {
 			this.label_upload_format.LanguageKey = "photobucket.label_upload_format";
 			this.label_upload_format.Location = new System.Drawing.Point(12, 14);
 			this.label_upload_format.Name = "label_upload_format";
-			this.label_upload_format.Size = new System.Drawing.Size(84, 20);
+			this.label_upload_format.Size = new System.Drawing.Size(88, 20);
 			this.label_upload_format.TabIndex = 9;
 			// 
 			// checkbox_usepagelink
@@ -104,7 +104,7 @@ namespace Greenshot.Plugin.Photobucket.Forms {
 			this.checkbox_usepagelink.Name = "checkbox_usepagelink";
 			this.checkbox_usepagelink.PropertyName = nameof(PhotobucketConfiguration.UsePageLink);
 			this.checkbox_usepagelink.SectionName = "Photobucket";
-			this.checkbox_usepagelink.Size = new System.Drawing.Size(251, 17);
+			this.checkbox_usepagelink.Size = new System.Drawing.Size(360, 20);
 			this.checkbox_usepagelink.TabIndex = 2;
 			this.checkbox_usepagelink.UseVisualStyleBackColor = true;
 			// 

--- a/src/Greenshot/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot/Forms/SettingsForm.Designer.cs
@@ -187,7 +187,7 @@ namespace Greenshot.Forms {
 			this.label_storagelocation.LanguageKey = "settings_storagelocation";
 			this.label_storagelocation.Location = new System.Drawing.Point(6, 21);
 			this.label_storagelocation.Name = "label_storagelocation";
-			this.label_storagelocation.Size = new System.Drawing.Size(126, 23);
+			this.label_storagelocation.Size = new System.Drawing.Size(130, 23);
 			this.label_storagelocation.TabIndex = 11;
 			// 
 			// settings_cancel
@@ -225,7 +225,7 @@ namespace Greenshot.Forms {
 			this.label_screenshotname.LanguageKey = "settings_filenamepattern";
 			this.label_screenshotname.Location = new System.Drawing.Point(6, 44);
 			this.label_screenshotname.Name = "label_screenshotname";
-			this.label_screenshotname.Size = new System.Drawing.Size(126, 23);
+			this.label_screenshotname.Size = new System.Drawing.Size(130, 23);
 			this.label_screenshotname.TabIndex = 9;
 			// 
 			// textbox_screenshotname
@@ -270,7 +270,7 @@ namespace Greenshot.Forms {
 			this.label_primaryimageformat.LanguageKey = "settings_primaryimageformat";
 			this.label_primaryimageformat.Location = new System.Drawing.Point(6, 67);
 			this.label_primaryimageformat.Name = "label_primaryimageformat";
-			this.label_primaryimageformat.Size = new System.Drawing.Size(126, 19);
+			this.label_primaryimageformat.Size = new System.Drawing.Size(130, 20);
 			this.label_primaryimageformat.TabIndex = 8;
 			// 
 			// groupbox_preferredfilesettings
@@ -340,7 +340,7 @@ namespace Greenshot.Forms {
 			this.label_icon_size.LanguageKey = "settings_iconsize";
 			this.label_icon_size.Location = new System.Drawing.Point(6, 44);
 			this.label_icon_size.Name = "label_icon_size";
-			this.label_icon_size.Size = new System.Drawing.Size(350, 16);
+			this.label_icon_size.Size = new System.Drawing.Size(350, 20);
 			this.label_icon_size.TabIndex = 6;
 			// 
 			// checkbox_autostartshortcut
@@ -391,7 +391,7 @@ namespace Greenshot.Forms {
 			this.label_jpegquality.LanguageKey = "settings_jpegquality";
 			this.label_jpegquality.Location = new System.Drawing.Point(6, 24);
 			this.label_jpegquality.Name = "label_jpegquality";
-			this.label_jpegquality.Size = new System.Drawing.Size(116, 23);
+			this.label_jpegquality.Size = new System.Drawing.Size(130, 23);
 			this.label_jpegquality.TabIndex = 13;
 			// 
 			// textBoxJpegQuality
@@ -678,7 +678,7 @@ namespace Greenshot.Forms {
 			this.radiobuttonWindowCapture.LanguageKey = "settings_window_capture_mode";
 			this.radiobuttonWindowCapture.Location = new System.Drawing.Point(11, 44);
 			this.radiobuttonWindowCapture.Name = "radiobuttonWindowCapture";
-			this.radiobuttonWindowCapture.Size = new System.Drawing.Size(132, 17);
+			this.radiobuttonWindowCapture.Size = new System.Drawing.Size(200, 20);
 			this.radiobuttonWindowCapture.TabIndex = 7;
 			this.radiobuttonWindowCapture.TabStop = true;
 			this.radiobuttonWindowCapture.UseVisualStyleBackColor = true;
@@ -689,7 +689,7 @@ namespace Greenshot.Forms {
 			this.radiobuttonInteractiveCapture.Location = new System.Drawing.Point(11, 20);
 			this.radiobuttonInteractiveCapture.Name = "radiobuttonInteractiveCapture";
 			this.radiobuttonInteractiveCapture.PropertyName = nameof(CoreConfiguration.CaptureWindowsInteractive);
-			this.radiobuttonInteractiveCapture.Size = new System.Drawing.Size(203, 17);
+			this.radiobuttonInteractiveCapture.Size = new System.Drawing.Size(203, 20);
 			this.radiobuttonInteractiveCapture.TabIndex = 6;
 			this.radiobuttonInteractiveCapture.TabStop = true;
 			this.radiobuttonInteractiveCapture.UseVisualStyleBackColor = true;
@@ -784,7 +784,7 @@ namespace Greenshot.Forms {
 			this.label_waittime.LanguageKey = "settings_waittime";
 			this.label_waittime.Location = new System.Drawing.Point(72, 106);
 			this.label_waittime.Name = "label_waittime";
-			this.label_waittime.Size = new System.Drawing.Size(331, 16);
+			this.label_waittime.Size = new System.Drawing.Size(331, 20);
 			this.label_waittime.TabIndex = 5;
 			// 
 			// tab_output
@@ -832,7 +832,7 @@ namespace Greenshot.Forms {
 			this.groupBoxColors.LanguageKey = "printoptions_colors";
 			this.groupBoxColors.Location = new System.Drawing.Point(6, 163);
 			this.groupBoxColors.Name = "groupBoxColors";
-			this.groupBoxColors.Size = new System.Drawing.Size(331, 124);
+			this.groupBoxColors.Size = new System.Drawing.Size(412, 124);
 			this.groupBoxColors.TabIndex = 10;
 			this.groupBoxColors.TabStop = false;
 			// 
@@ -844,7 +844,7 @@ namespace Greenshot.Forms {
 			this.checkboxPrintInverted.Location = new System.Drawing.Point(13, 88);
 			this.checkboxPrintInverted.Name = "checkboxPrintInverted";
 			this.checkboxPrintInverted.PropertyName = nameof(CoreConfiguration.OutputPrintInverted);
-			this.checkboxPrintInverted.Size = new System.Drawing.Size(141, 17);
+			this.checkboxPrintInverted.Size = new System.Drawing.Size(390, 20);
 			this.checkboxPrintInverted.TabIndex = 14;
 			this.checkboxPrintInverted.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxPrintInverted.UseVisualStyleBackColor = true;
@@ -856,7 +856,7 @@ namespace Greenshot.Forms {
 			this.radioBtnColorPrint.LanguageKey = "printoptions_printcolor";
 			this.radioBtnColorPrint.Location = new System.Drawing.Point(13, 19);
 			this.radioBtnColorPrint.Name = "radioBtnColorPrint";
-			this.radioBtnColorPrint.Size = new System.Drawing.Size(90, 17);
+			this.radioBtnColorPrint.Size = new System.Drawing.Size(390, 20);
 			this.radioBtnColorPrint.TabIndex = 11;
 			this.radioBtnColorPrint.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.radioBtnColorPrint.UseVisualStyleBackColor = true;
@@ -869,7 +869,7 @@ namespace Greenshot.Forms {
 			this.radioBtnGrayScale.Location = new System.Drawing.Point(13, 42);
 			this.radioBtnGrayScale.Name = "radioBtnGrayScale";
 			this.radioBtnGrayScale.PropertyName = nameof(coreConfiguration.OutputPrintGrayscale);
-			this.radioBtnGrayScale.Size = new System.Drawing.Size(137, 17);
+			this.radioBtnGrayScale.Size = new System.Drawing.Size(390, 20);
 			this.radioBtnGrayScale.TabIndex = 12;
 			this.radioBtnGrayScale.Text = "Force grayscale printing";
 			this.radioBtnGrayScale.TextAlign = System.Drawing.ContentAlignment.TopLeft;
@@ -883,7 +883,7 @@ namespace Greenshot.Forms {
 			this.radioBtnMonochrome.Location = new System.Drawing.Point(13, 65);
 			this.radioBtnMonochrome.Name = "radioBtnMonochrome";
 			this.radioBtnMonochrome.PropertyName = nameof(coreConfiguration.OutputPrintMonochrome);
-			this.radioBtnMonochrome.Size = new System.Drawing.Size(148, 17);
+			this.radioBtnMonochrome.Size = new System.Drawing.Size(390, 20);
 			this.radioBtnMonochrome.TabIndex = 13;
 			this.radioBtnMonochrome.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.radioBtnMonochrome.UseVisualStyleBackColor = true;
@@ -898,7 +898,7 @@ namespace Greenshot.Forms {
 			this.groupBoxPrintLayout.LanguageKey = "printoptions_layout";
 			this.groupBoxPrintLayout.Location = new System.Drawing.Point(6, 6);
 			this.groupBoxPrintLayout.Name = "groupBoxPrintLayout";
-			this.groupBoxPrintLayout.Size = new System.Drawing.Size(331, 151);
+			this.groupBoxPrintLayout.Size = new System.Drawing.Size(412, 151);
 			this.groupBoxPrintLayout.TabIndex = 1;
 			this.groupBoxPrintLayout.TabStop = false;
 			// 
@@ -910,7 +910,7 @@ namespace Greenshot.Forms {
 			this.checkboxDateTime.Location = new System.Drawing.Point(13, 115);
 			this.checkboxDateTime.Name = "checkboxDateTime";
 			this.checkboxDateTime.PropertyName = nameof(coreConfiguration.OutputPrintFooter);
-			this.checkboxDateTime.Size = new System.Drawing.Size(187, 17);
+			this.checkboxDateTime.Size = new System.Drawing.Size(390, 20);
 			this.checkboxDateTime.TabIndex = 6;
 			this.checkboxDateTime.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxDateTime.UseVisualStyleBackColor = true;
@@ -923,7 +923,7 @@ namespace Greenshot.Forms {
 			this.checkboxAllowShrink.Location = new System.Drawing.Point(13, 23);
 			this.checkboxAllowShrink.Name = "checkboxAllowShrink";
 			this.checkboxAllowShrink.PropertyName = nameof(coreConfiguration.OutputPrintAllowShrink);
-			this.checkboxAllowShrink.Size = new System.Drawing.Size(168, 17);
+			this.checkboxAllowShrink.Size = new System.Drawing.Size(390, 20);
 			this.checkboxAllowShrink.TabIndex = 2;
 			this.checkboxAllowShrink.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxAllowShrink.UseVisualStyleBackColor = true;
@@ -936,7 +936,7 @@ namespace Greenshot.Forms {
 			this.checkboxAllowEnlarge.Location = new System.Drawing.Point(13, 46);
 			this.checkboxAllowEnlarge.Name = "checkboxAllowEnlarge";
 			this.checkboxAllowEnlarge.PropertyName = nameof(coreConfiguration.OutputPrintAllowEnlarge);
-			this.checkboxAllowEnlarge.Size = new System.Drawing.Size(174, 17);
+			this.checkboxAllowEnlarge.Size = new System.Drawing.Size(390, 20);
 			this.checkboxAllowEnlarge.TabIndex = 3;
 			this.checkboxAllowEnlarge.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxAllowEnlarge.UseVisualStyleBackColor = true;
@@ -949,7 +949,7 @@ namespace Greenshot.Forms {
 			this.checkboxAllowRotate.Location = new System.Drawing.Point(13, 69);
 			this.checkboxAllowRotate.Name = "checkboxAllowRotate";
 			this.checkboxAllowRotate.PropertyName = nameof(coreConfiguration.OutputPrintAllowRotate);
-			this.checkboxAllowRotate.Size = new System.Drawing.Size(187, 17);
+			this.checkboxAllowRotate.Size = new System.Drawing.Size(390, 20);
 			this.checkboxAllowRotate.TabIndex = 4;
 			this.checkboxAllowRotate.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxAllowRotate.UseVisualStyleBackColor = true;
@@ -962,7 +962,7 @@ namespace Greenshot.Forms {
 			this.checkboxAllowCenter.Location = new System.Drawing.Point(13, 92);
 			this.checkboxAllowCenter.Name = "checkboxAllowCenter";
 			this.checkboxAllowCenter.PropertyName = nameof(coreConfiguration.OutputPrintCenter);
-			this.checkboxAllowCenter.Size = new System.Drawing.Size(137, 17);
+			this.checkboxAllowCenter.Size = new System.Drawing.Size(390, 20);
 			this.checkboxAllowCenter.TabIndex = 5;
 			this.checkboxAllowCenter.TextAlign = System.Drawing.ContentAlignment.TopLeft;
 			this.checkboxAllowCenter.UseVisualStyleBackColor = true;
@@ -973,7 +973,7 @@ namespace Greenshot.Forms {
 			this.checkbox_alwaysshowprintoptionsdialog.Location = new System.Drawing.Point(19, 293);
 			this.checkbox_alwaysshowprintoptionsdialog.Name = "checkbox_alwaysshowprintoptionsdialog";
 			this.checkbox_alwaysshowprintoptionsdialog.PropertyName = nameof(coreConfiguration.OutputPrintPromptOptions);
-			this.checkbox_alwaysshowprintoptionsdialog.Size = new System.Drawing.Size(394, 20);
+			this.checkbox_alwaysshowprintoptionsdialog.Size = new System.Drawing.Size(394, 24);
 			this.checkbox_alwaysshowprintoptionsdialog.TabIndex = 15;
 			this.checkbox_alwaysshowprintoptionsdialog.Text = "Show print options dialog every time an image is printed";
 			this.checkbox_alwaysshowprintoptionsdialog.UseVisualStyleBackColor = true;
@@ -1071,7 +1071,7 @@ namespace Greenshot.Forms {
 			this.checkbox_reuseeditor.Name = "checkbox_reuseeditor";
 			this.checkbox_reuseeditor.PropertyName = nameof(EditorConfiguration.ReuseEditor);
 			this.checkbox_reuseeditor.SectionName = "Editor";
-			this.checkbox_reuseeditor.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_reuseeditor.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_reuseeditor.TabIndex = 9;
 			this.checkbox_reuseeditor.UseVisualStyleBackColor = true;
 			// 
@@ -1081,7 +1081,7 @@ namespace Greenshot.Forms {
 			this.checkbox_minimizememoryfootprint.Location = new System.Drawing.Point(10, 202);
 			this.checkbox_minimizememoryfootprint.Name = "checkbox_minimizememoryfootprint";
 			this.checkbox_minimizememoryfootprint.PropertyName = nameof(coreConfiguration.MinimizeWorkingSetSize);
-			this.checkbox_minimizememoryfootprint.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_minimizememoryfootprint.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_minimizememoryfootprint.TabIndex = 8;
 			this.checkbox_minimizememoryfootprint.UseVisualStyleBackColor = true;
 			// 
@@ -1091,7 +1091,7 @@ namespace Greenshot.Forms {
 			this.checkbox_checkunstableupdates.Location = new System.Drawing.Point(10, 184);
 			this.checkbox_checkunstableupdates.Name = "checkbox_checkunstableupdates";
 			this.checkbox_checkunstableupdates.PropertyName = nameof(coreConfiguration.CheckForUnstable);
-			this.checkbox_checkunstableupdates.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_checkunstableupdates.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_checkunstableupdates.TabIndex = 7;
 			this.checkbox_checkunstableupdates.UseVisualStyleBackColor = true;
 			// 
@@ -1102,7 +1102,7 @@ namespace Greenshot.Forms {
 			this.checkbox_suppresssavedialogatclose.Name = "checkbox_suppresssavedialogatclose";
 			this.checkbox_suppresssavedialogatclose.PropertyName = nameof(EditorConfiguration.SuppressSaveDialogAtClose);
 			this.checkbox_suppresssavedialogatclose.SectionName = "Editor";
-			this.checkbox_suppresssavedialogatclose.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_suppresssavedialogatclose.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_suppresssavedialogatclose.TabIndex = 6;
 			this.checkbox_suppresssavedialogatclose.UseVisualStyleBackColor = true;
 			// 
@@ -1111,7 +1111,7 @@ namespace Greenshot.Forms {
 			this.label_counter.LanguageKey = "expertsettings_counter";
 			this.label_counter.Location = new System.Drawing.Point(7, 270);
 			this.label_counter.Name = "label_counter";
-			this.label_counter.Size = new System.Drawing.Size(246, 13);
+			this.label_counter.Size = new System.Drawing.Size(246, 20);
 			this.label_counter.TabIndex = 27;
 			//
 			// textbox_counter
@@ -1127,7 +1127,7 @@ namespace Greenshot.Forms {
 			this.label_footerpattern.LanguageKey = "expertsettings_footerpattern";
 			this.label_footerpattern.Location = new System.Drawing.Point(7, 244);
 			this.label_footerpattern.Name = "label_footerpattern";
-			this.label_footerpattern.Size = new System.Drawing.Size(103, 13);
+			this.label_footerpattern.Size = new System.Drawing.Size(130, 20);
 			this.label_footerpattern.TabIndex = 25;
 			this.label_footerpattern.Text = "Printer footer pattern";
 			//
@@ -1145,7 +1145,7 @@ namespace Greenshot.Forms {
 			this.checkbox_thumbnailpreview.Location = new System.Drawing.Point(10, 148);
 			this.checkbox_thumbnailpreview.Name = "checkbox_thumbnailpreview";
 			this.checkbox_thumbnailpreview.PropertyName = nameof(coreConfiguration.ThumnailPreview);
-			this.checkbox_thumbnailpreview.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_thumbnailpreview.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_thumbnailpreview.TabIndex = 5;
 			this.checkbox_thumbnailpreview.UseVisualStyleBackColor = true;
 			// 
@@ -1155,7 +1155,7 @@ namespace Greenshot.Forms {
 			this.checkbox_optimizeforrdp.Location = new System.Drawing.Point(10, 130);
 			this.checkbox_optimizeforrdp.Name = "checkbox_optimizeforrdp";
 			this.checkbox_optimizeforrdp.PropertyName = nameof(coreConfiguration.OptimizeForRDP);
-			this.checkbox_optimizeforrdp.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_optimizeforrdp.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_optimizeforrdp.TabIndex = 4;
 			this.checkbox_optimizeforrdp.UseVisualStyleBackColor = true;
 			// 
@@ -1165,7 +1165,7 @@ namespace Greenshot.Forms {
 			this.checkbox_autoreducecolors.Location = new System.Drawing.Point(10, 112);
 			this.checkbox_autoreducecolors.Name = "checkbox_autoreducecolors";
 			this.checkbox_autoreducecolors.PropertyName = nameof(coreConfiguration.OutputFileAutoReduceColors);
-			this.checkbox_autoreducecolors.Size = new System.Drawing.Size(394, 17);
+			this.checkbox_autoreducecolors.Size = new System.Drawing.Size(394, 20);
 			this.checkbox_autoreducecolors.TabIndex = 3;
 			this.checkbox_autoreducecolors.UseVisualStyleBackColor = true;
 			// 
@@ -1174,7 +1174,7 @@ namespace Greenshot.Forms {
 			this.label_clipboardformats.LanguageKey = "expertsettings_clipboardformats";
 			this.label_clipboardformats.Location = new System.Drawing.Point(7, 39);
 			this.label_clipboardformats.Name = "label_clipboardformats";
-			this.label_clipboardformats.Size = new System.Drawing.Size(88, 13);
+			this.label_clipboardformats.Size = new System.Drawing.Size(160, 20);
 			this.label_clipboardformats.TabIndex = 20;
 			// 
 			// checkbox_enableexpert


### PR DESCRIPTION
I have extended groupboxes and labels to fit in the majority of languages to the fullest extent they can comfortably go without extending the main form size. This should hopefully fix the issues with labels being truncated until we can move to WPF.

I have tested at different resolutions, and also DP,I and this looks to work just fine as it is merely an extension of labels.

@Lakritzator I couldn't settle knowing lables were not showing their full text after closing https://github.com/greenshot/greenshot/pull/900.

This will fix https://github.com/greenshot/greenshot/issues/896

<img width="511" height="526" alt="image" src="https://github.com/user-attachments/assets/b318b3d3-3bcf-4b42-8332-cddd97a36b35" />

<img width="511" height="521" alt="image" src="https://github.com/user-attachments/assets/63d45216-5f48-4529-990c-136e040fe590" />
