### PR TITLE
Fix Windows Share & Rename OCR to work with Windows 10 & 11

### DIFF
--- a/src/Greenshot/Configuration/Win10Configuration.cs
+++ b/src/Greenshot/Configuration/Win10Configuration.cs
@@ -26,7 +26,7 @@ namespace Greenshot.Configuration
     /// <summary>
     /// Description of Win10Configuration.
     /// </summary>
-    [IniSection("Win10", Description = "Greenshot Win10 Plugin configuration")]
+    [IniSection("Win10", Description = "Greenshot Windows Plugin configuration")]
     public class Win10Configuration : IniSection
     {
         [IniProperty("AlwaysRunOCROnCapture", Description = "Determines if OCR is run automatically on every capture", DefaultValue = "False")]

--- a/src/Greenshot/Destinations/Win10OcrDestination.cs
+++ b/src/Greenshot/Destinations/Win10OcrDestination.cs
@@ -30,14 +30,14 @@ using Greenshot.Base.Interfaces.Ocr;
 namespace Greenshot.Destinations
 {
     /// <summary>
-    /// This uses the OcrEngine from Windows 10 to perform OCR on the captured image.
+    /// This uses the Windows OcrEngine to perform OCR on the captured image.
     /// </summary>
     public class Win10OcrDestination : AbstractDestination
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(typeof(Win10OcrDestination));
 
         public override string Designation { get; } = "Windows10OCR";
-        public override string Description { get; } = "Windows 10 OCR";
+        public override string Description { get; } = "Windows OCR";
 
         public override int Priority => 3;
 
@@ -59,7 +59,7 @@ namespace Greenshot.Destinations
         }
 
         /// <summary>
-        /// Run the Windows 10 OCR engine to process the text on the captured image
+        /// Run the Windows OCR engine to process the text on the captured image
         /// </summary>
         /// <param name="manuallyInitiated"></param>
         /// <param name="surface"></param>

--- a/src/Greenshot/Destinations/Win10ShareDestination.cs
+++ b/src/Greenshot/Destinations/Win10ShareDestination.cs
@@ -29,14 +29,14 @@ using System.Windows.Forms;
 namespace Greenshot.Destinations
 {
     /// <summary>
-    /// This uses the Share from Windows 10 to make the capture available to apps.
+    /// This uses the Windows Share dialog to make the capture available to apps.
     /// </summary>
     public class Win10ShareDestination : AbstractDestination
     {
         private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(typeof(Win10ShareDestination));
 
         public override string Designation { get; } = "Windows10Share";
-        public override string Description { get; } = "Windows 10 share";
+        public override string Description { get; } = "Windows share";
 
         public override int Priority => 3;
 

--- a/src/Greenshot/Forms/SharingForm.Designer.cs
+++ b/src/Greenshot/Forms/SharingForm.Designer.cs
@@ -50,14 +50,15 @@ namespace Greenshot.Forms {
 		/// not be able to load this method if it was changed manually.
 		/// </summary>
 		private void InitializeComponent() {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SharingForm));
             this.SuspendLayout();
-            // 
+            //
             // SharingForm
-            // 
-            this.ClientSize = new System.Drawing.Size(284, 261);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            //
+            this.ClientSize = new System.Drawing.Size(0, 0);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "SharingForm";
+            this.Opacity = 0;
+            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.ResumeLayout(false);
 

--- a/src/Greenshot/Forms/SharingForm.cs
+++ b/src/Greenshot/Forms/SharingForm.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Windows;
 using Greenshot.Base.Core;
 using Greenshot.Base.Core.Enums;
@@ -40,7 +39,7 @@ using Color = Windows.UI.Color;
 namespace Greenshot.Forms
 {
     /// <summary>
-    /// The sharing form
+    /// Form that displays the Windows Share UI for sharing captures to other apps
     /// </summary>
     public sealed partial class SharingForm : BaseForm
     {
@@ -91,15 +90,12 @@ namespace Greenshot.Forms
             _dtmInterop = DataTransferManagerHelper.GetInteropFactory("Windows.ApplicationModel.DataTransfer.DataTransferManager");
 
             IntPtr hwnd = this.Handle;
-            IntPtr pDtm = IntPtr.Zero;
-            // Interface for IUnknown
-            Guid iidUnknown = new Guid("00000000-0000-0000-C000-000000000046");
+            // IID of DataTransferManager - required for correct COM projection on both Windows 10 and 11
+            Guid dtmIid = new Guid("a5caee9b-8708-49d1-8d36-67d25a8da00c");
 
-            _dtmInterop.GetForWindow(hwnd, ref iidUnknown, out pDtm);
+            _dataTransferManager = _dtmInterop.GetForWindow(hwnd, ref dtmIid);
 
-            if (pDtm == IntPtr.Zero) throw new Exception("GetForWindow returned a null pointer.");
-
-            _dataTransferManager = (DataTransferManager)Marshal.GetObjectForIUnknown(pDtm);
+            if (_dataTransferManager == null) throw new Exception("GetForWindow returned null.");
 
             // 1. Hook the Data Request (Setup content)
             _dataTransferManager.DataRequested += OnDataRequested;

--- a/src/Greenshot/Native/IDataTransferManagerInterOp.cs
+++ b/src/Greenshot/Native/IDataTransferManagerInterOp.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Greenshot.Native
 {
@@ -37,8 +38,8 @@ namespace Greenshot.Native
         /// </summary>
         /// <param name="appWindow">The window handle</param>
         /// <param name="riid">ID of the DataTransferManager interface</param>
-        /// <param name="dataTransferManager">IntPtr dataTransferManager</param>
-        void GetForWindow([In] IntPtr appWindow, [In] ref Guid riid, out IntPtr dataTransferManager);
+        /// <returns>DataTransferManager for the specified window</returns>
+        DataTransferManager GetForWindow([In] IntPtr appWindow, [In] ref Guid riid);
         /// <summary>
         /// Show the share flyout for the window identified by a window handle
         /// </summary>

--- a/src/Greenshot/Native/Win10OcrProvider.cs
+++ b/src/Greenshot/Native/Win10OcrProvider.cs
@@ -37,7 +37,7 @@ using Greenshot.Base.Interfaces.Plugin;
 namespace Greenshot.Plugin.Win10
 {
     /// <summary>
-    /// This uses the OcrEngine from Windows 10 to perform OCR on the captured image.
+    /// This uses the Windows OcrEngine to perform OCR on the captured image.
     /// </summary>
     public class Win10OcrProvider : IOcrProvider
     {

--- a/src/Greenshot/Processors/Win10OcrProcessor.cs
+++ b/src/Greenshot/Processors/Win10OcrProcessor.cs
@@ -36,7 +36,7 @@ namespace Greenshot.Processors
         private static readonly Win10Configuration Win10Configuration = IniConfig.GetIniSection<Win10Configuration>();
         public override string Designation => "Windows10OcrProcessor";
 
-        public override string Description => Designation;
+        public override string Description => "Windows OCR";
 
         public override bool ProcessCapture(ISurface surface, ICaptureDetails captureDetails)
         {


### PR DESCRIPTION
Rename the "Windows 10 Share" and "Windows 10 OCR" features to just "Windows Share" and "Windows OCR" now that Win10 is EOL.

Fixed the share feature not working on Windows 11 - turns out there were two issues: a missing .resx file was causing a silent MissingManifestResourceException that made the whole thing look like it did nothing, and the COM interop was passing the wrong GUID (IUnknown instead of the DataTransferManager IID) to GetForWindow.

Updated the interface to return DataTransferManager directly instead of messing around with raw IntPtr marshalling, which matches what Microsoft's own reference sample does.

Also made the SharingForm invisible since it's just there to own the HWND for the share dialogue. Internal designation strings left as-is so existing user configs don't break.

https://github.com/greenshot/greenshot/issues/534 - Fixing GS to use New Outlook doesn't look like it will work given that New Outlook is a Web App; however, the best solution looks to be to update GS to use Windows Share in Windows 11 to work.

Works both from the editor and from having Windows Share as a destination.

Backwards compatibility with Windows 10 is maintained.

<img width="1308" height="764" alt="image" src="https://github.com/user-attachments/assets/1c52a3df-0320-4a14-8cb4-52e596bb1901" />
