### PR TITLE
Remove the Outlook Share button if using New Outlook

### DIFF
--- a/src/Greenshot/Destinations/EmailDestination.cs
+++ b/src/Greenshot/Destinations/EmailDestination.cs
@@ -81,9 +81,8 @@ namespace Greenshot.Destinations
                 if (_isActiveFlag)
                 {
                     // Disable if the office plugin is installed and the client is outlook
-                    // TODO: Change this! It always creates an exception, as the plugin has not been loaded the type is not there :(
-                    var outlookDestination = Type.GetType("GreenshotOfficePlugin.OutlookDestination,GreenshotOfficePlugin", false);
-                    if (outlookDestination != null && _mapiClient.ToLower().Contains("microsoft outlook"))
+                    var outlookDestination = Type.GetType("Greenshot.Plugin.Office.Destinations.OutlookDestination,Greenshot.Plugin.Office", false);
+                    if (outlookDestination != null && _mapiClient.ToLower().Contains("outlook"))
                     {
                         _isActiveFlag = false;
                     }


### PR DESCRIPTION
Fixed the Outlook button showing up and throwing a MAPI error when you only have New Outlook (olk.exe) installed instead of classic Outlook.

New Outlook is a Web App, and the easiest way to interact with the app is by sharing screenshots with it.

This fixes the issue reported in https://github.com/greenshot/greenshot/issues/534.

The root cause was a broken type name in EmailDestination.cs that was supposed to check if the Office plugin was handling Outlook — it used the wrong namespace and assembly name, so the check always failed, meaning the MAPI email button would appear even though MAPI doesn't work with New Outlook.

Fixed the type reference from GreenshotOfficePlugin.OutlookDestination,GreenshotOfficePlugin to the correct Greenshot.Plugin.Office.Destinations.OutlookDestination,Greenshot.Plugin.Office, and relaxed the client name check to match any Outlook variant.

Now the broken email button won't show up when classic Outlook isn't installed.