### PR TITLE
Add new capture technology

### DIFF
--- a/src/Greenshot/Helpers/CaptureHelper.cs
+++ b/src/Greenshot/Helpers/CaptureHelper.cs
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-using log4net;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -42,6 +41,8 @@ using Greenshot.Configuration;
 using Greenshot.Editor.Destinations;
 using Greenshot.Editor.Drawing;
 using Greenshot.Forms;
+using Greenshot.Native;
+using log4net;
 
 namespace Greenshot.Helpers
 {
@@ -908,6 +909,14 @@ namespace Greenshot.Helpers
             if (captureForWindow == null)
             {
                 captureForWindow = new Capture();
+            }
+
+            // New simplified logic with 1.4, using WindowsGraphicsCapture
+            if (CoreConfig.IsBetaTester)
+            {
+                captureForWindow.Image = WindowsGraphicsCaptureInterop.CaptureWindowToBitmap(windowToCapture.Handle);
+                captureForWindow.CaptureDetails.Title = windowToCapture.Text;
+                return captureForWindow;
             }
 
             NativeRect windowRectangle = windowToCapture.WindowRectangle;

--- a/src/Greenshot/Native/DirectX/D3D11_CPU_ACCESS_FLAG.cs
+++ b/src/Greenshot/Native/DirectX/D3D11_CPU_ACCESS_FLAG.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Defines flags that specify CPU access options for Direct3D 11 resources.
+/// </summary>
+/// <remarks>This enumeration is used to indicate the type of access that the CPU has to a resource, which can
+/// affect performance and resource management. The flags can be combined to specify multiple access types.</remarks>
+internal enum D3D11_CPU_ACCESS_FLAG
+{
+    D3D11_CPU_ACCESS_WRITE = 0x10000,
+    D3D11_CPU_ACCESS_READ = 0x20000
+}

--- a/src/Greenshot/Native/DirectX/D3D11_MAP.cs
+++ b/src/Greenshot/Native/DirectX/D3D11_MAP.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Specifies the options for accessing a resource when mapping it in Direct3D 11 operations.
+/// </summary>
+/// <remarks>Each value in the D3D11_MAP enumeration defines a distinct access pattern for mapped resources, such
+/// as read-only, write-only, or read-write access. The choice of mapping option can affect performance and resource
+/// management. Use the appropriate value based on the intended usage and requirements of the resource during rendering
+/// or data transfer operations.</remarks>
+internal enum D3D11_MAP
+{
+    D3D11_MAP_READ = 1,
+    D3D11_MAP_WRITE = 2,
+    D3D11_MAP_READ_WRITE = 3,
+    D3D11_MAP_WRITE_DISCARD = 4,
+    D3D11_MAP_WRITE_NO_OVERWRITE = 5
+}

--- a/src/Greenshot/Native/DirectX/D3D11_MAPPED_SUBRESOURCE.cs
+++ b/src/Greenshot/Native/DirectX/D3D11_MAPPED_SUBRESOURCE.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a mapped subresource in Direct3D 11, providing access to the resource's data and its layout information.
+/// </summary>
+/// <remarks>This structure is used when mapping a resource to access its data directly. The `pData` field points
+/// to the mapped data, while `RowPitch` and `DepthPitch` provide the pitch information for the resource's layout in
+/// memory.</remarks>
+[StructLayout(LayoutKind.Sequential)]
+internal struct D3D11_MAPPED_SUBRESOURCE
+{
+    public IntPtr pData;
+    public int RowPitch;
+    public int DepthPitch;
+}

--- a/src/Greenshot/Native/DirectX/D3D11_TEXTURE2D_DESC.cs
+++ b/src/Greenshot/Native/DirectX/D3D11_TEXTURE2D_DESC.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Describes the properties of a two-dimensional texture resource used in Direct3D 11, including its dimensions,
+/// format, mip levels, array size, sampling options, usage, binding, CPU access, and miscellaneous flags.
+/// </summary>
+/// <remarks>This structure is used to configure and define the characteristics of a 2D texture when creating
+/// resources in Direct3D 11. It allows developers to specify how the texture will be stored, accessed, and utilized
+/// within the graphics pipeline. The fields correspond to key aspects such as width, height, pixel format, number of
+/// mipmap levels, array slices, multisampling settings, intended usage, binding options, CPU access permissions, and
+/// additional resource flags. Proper configuration of these properties is essential for optimal performance and
+/// compatibility in graphics applications.</remarks>
+[StructLayout(LayoutKind.Sequential)]
+internal struct D3D11_TEXTURE2D_DESC
+{
+    public int Width;
+    public int Height;
+    public int MipLevels;
+    public int ArraySize;
+    public int Format;
+    public DXGI_SAMPLE_DESC SampleDesc;
+    public D3D11_USAGE Usage;
+    public int BindFlags;
+    public D3D11_CPU_ACCESS_FLAG CPUAccessFlags;
+    public int MiscFlags;
+}

--- a/src/Greenshot/Native/DirectX/D3D11_USAGE.cs
+++ b/src/Greenshot/Native/DirectX/D3D11_USAGE.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Specifies the usage options for Direct3D 11 resources, indicating how resources are intended to be accessed and
+/// managed by the CPU and GPU.
+/// </summary>
+/// <remarks>Each value of the D3D11_USAGE enumeration defines a distinct resource usage pattern:
+/// D3D11_USAGE_DEFAULT is optimized for GPU access and is suitable for resources that are updated infrequently;
+/// D3D11_USAGE_IMMUTABLE is for resources that are set once and never changed; D3D11_USAGE_DYNAMIC allows frequent
+/// updates from the CPU, typically for resources that change often; D3D11_USAGE_STAGING is used for resources that are
+/// read from or written to by the CPU, often for data transfer operations. The selected usage affects performance
+/// characteristics and determines which operations are permitted on the resource.</remarks>
+internal enum D3D11_USAGE
+{
+    D3D11_USAGE_DEFAULT = 0,
+    D3D11_USAGE_IMMUTABLE = 1,
+    D3D11_USAGE_DYNAMIC = 2,
+    D3D11_USAGE_STAGING = 3
+}

--- a/src/Greenshot/Native/DirectX/DXGI_SAMPLE_DESC.cs
+++ b/src/Greenshot/Native/DirectX/DXGI_SAMPLE_DESC.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Describes the multi-sample parameters for a DirectX swap chain, including the number of samples and the quality
+/// level used for anti-aliasing.
+/// </summary>
+/// <remarks>This structure is used to configure multi-sampling in graphics rendering. The Count field specifies
+/// how many samples are used per pixel, while the Quality field indicates the quality level of those samples. Higher
+/// values for Count and Quality can improve visual fidelity but may impact performance. These settings should match the
+/// capabilities of the graphics device and the requirements of the application.</remarks>
+[StructLayout(LayoutKind.Sequential)]
+internal struct DXGI_SAMPLE_DESC
+{
+    public int Count;
+    public int Quality;
+}

--- a/src/Greenshot/Native/DirectX/ID3D11Device.cs
+++ b/src/Greenshot/Native/DirectX/ID3D11Device.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a Direct3D 11 device that provides methods for creating and managing graphics resources such as buffers
+/// and textures.
+/// </summary>
+/// <remarks>This interface is essential for initializing and handling Direct3D resources in graphics
+/// applications. It enables the creation of various resource types required for rendering operations and serves as the
+/// entry point for resource management in Direct3D 11. Typically, instances of this interface are obtained through
+/// Direct3D initialization routines and are used throughout the application's lifetime to allocate and manage GPU
+/// resources.</remarks>
+[ComImport]
+[Guid("db6f6ddb-ac77-4e88-8253-819df9bbf140")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface ID3D11Device
+{
+    void CreateBuffer();
+    void CreateTexture1D();
+    void CreateTexture2D([In] ref D3D11_TEXTURE2D_DESC pDesc, [In] IntPtr pInitialData, [MarshalAs(UnmanagedType.Interface)] out ID3D11Texture2D ppTexture2D);
+}

--- a/src/Greenshot/Native/DirectX/ID3D11DeviceContext.cs
+++ b/src/Greenshot/Native/DirectX/ID3D11DeviceContext.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a Direct3D 11 device context, providing methods for issuing rendering commands and managing graphics
+/// resources within the Direct3D pipeline.
+/// </summary>
+/// <remarks>The ID3D11DeviceContext interface enables interaction with the Direct3D 11 rendering pipeline,
+/// including setting shaders, drawing geometry, and manipulating resource states. It is typically used in conjunction
+/// with an ID3D11Device to execute graphics operations and manage GPU resources. This interface is essential for
+/// performing tasks such as rendering, resource mapping, and configuring pipeline stages in Direct3D 11
+/// applications.</remarks>
+[ComImport]
+[Guid("c0bfa96c-e089-44fb-8eaf-26f8796190da")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface ID3D11DeviceContext
+{
+    // --- ID3D11DeviceChild Methods (Inherited) ---
+    // These placeholders ensure the VTable offsets are correct (Slots 3, 4, 5, 6)
+    void GetDevice();
+    void GetPrivateData();
+    void SetPrivateData();
+    void SetPrivateDataInterface();
+
+    // --- ID3D11DeviceContext Methods (Starts at Slot 7) ---
+    void VSSetConstantBuffers();
+    void PSSetShaderResources();
+    void PSSetShader();
+    void PSSetSamplers();
+    void VSSetShader();
+    void DrawIndexed();
+    void Draw();
+
+    // Map is Slot 14 (relative to DeviceContext start at 7? No, standard indexes map sequentially)
+    // IUnknown (3) + DeviceChild (4) + DeviceContext methods...
+    // Map is the 8th method defined in ID3D11DeviceContext itself.
+    // 7 + 7 = 14. This is correct.
+
+    [PreserveSig]
+    int Map([MarshalAs(UnmanagedType.Interface)] ID3D11Resource pResource, int Subresource, D3D11_MAP MapType, int MapFlags, out D3D11_MAPPED_SUBRESOURCE pMappedResource);
+
+    void Unmap([MarshalAs(UnmanagedType.Interface)] ID3D11Resource pResource, int Subresource);
+
+    void PSSetConstantBuffers();
+    void IASetInputLayout();
+    void IASetVertexBuffers();
+    void IASetIndexBuffer();
+    void DrawIndexedInstanced();
+    void DrawInstanced();
+    void GSSetConstantBuffers();
+    void GSSetShader();
+    void IASetPrimitiveTopology();
+    void VSSetShaderResources();
+    void VSSetSamplers();
+    void Begin();
+    void End();
+    void GetData();
+    void SetPredication();
+    void GSSetShaderResources();
+    void GSSetSamplers();
+    void OMSetRenderTargets();
+    void OMSetRenderTargetsAndUnorderedAccessViews();
+    void OMSetBlendState();
+    void OMSetDepthStencilState();
+    void SOSetTargets();
+    void DrawAuto();
+    void DrawIndexedInstancedIndirect();
+    void DrawInstancedIndirect();
+    void Dispatch();
+    void DispatchIndirect();
+    void RSSetState();
+    void RSSetViewports();
+    void RSSetScissorRects();
+    void CopySubresourceRegion();
+
+    void CopyResource([MarshalAs(UnmanagedType.Interface)] ID3D11Resource pDstResource, [MarshalAs(UnmanagedType.Interface)] ID3D11Resource pSrcResource);
+}

--- a/src/Greenshot/Native/DirectX/ID3D11Resource.cs
+++ b/src/Greenshot/Native/DirectX/ID3D11Resource.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a Direct3D 11 resource that can be used for rendering and resource management operations.
+/// </summary>
+/// <remarks>This interface serves as the base for all resource types in Direct3D 11, such as textures and
+/// buffers. It provides a common set of functionalities for handling resources within the Direct3D API.</remarks>
+[ComImport]
+[Guid("dc8e63f3-d12b-4952-b47b-5e45026a862d")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface ID3D11Resource { }

--- a/src/Greenshot/Native/DirectX/ID3D11Texture2D.cs
+++ b/src/Greenshot/Native/DirectX/ID3D11Texture2D.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a two-dimensional texture resource used in Direct3D 11 for storing and manipulating image data.
+/// </summary>
+/// <remarks>This interface provides methods to retrieve the texture's description and manage its resource
+/// properties. It is essential for rendering operations that require texture mapping in graphics
+/// applications.</remarks>
+[ComImport]
+[Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface ID3D11Texture2D : ID3D11Resource
+{
+    // ID3D11DeviceChild methods (inherited)
+    void GetDevice();
+    void GetPrivateData();
+    void SetPrivateData();
+    void SetPrivateDataInterface();
+
+    // ID3D11Resource methods (inherited)
+    void GetType();
+    void SetEvictionPriority();
+    void GetEvictionPriority();
+
+    // ID3D11Texture2D methods
+    void GetDesc(out D3D11_TEXTURE2D_DESC pDesc);
+}

--- a/src/Greenshot/Native/DirectX/IDXGIDevice.cs
+++ b/src/Greenshot/Native/DirectX/IDXGIDevice.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Represents a DirectX Graphics Infrastructure (DXGI) device used to create and manage Direct3D resources.
+/// </summary>
+/// <remarks>This interface enables interaction with graphics devices and facilitates resource management and
+/// coordination with the Direct3D runtime. It is typically used in graphics applications to support rendering
+/// operations and device-level resource handling.</remarks>
+[ComImport]
+[Guid("54ec77fa-1377-44e6-8c32-88fd5f44c84c")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IDXGIDevice { }

--- a/src/Greenshot/Native/DirectX/IDirect3DDxgiInterfaceAccess.cs
+++ b/src/Greenshot/Native/DirectX/IDirect3DDxgiInterfaceAccess.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Provides access to a specified interface for Direct3D resources.
+/// </summary>
+/// <remarks>This interface allows clients to retrieve a pointer to a Direct3D interface using its GUID. It is
+/// primarily used in scenarios where interoperability with Direct3D resources is required.</remarks>
+[ComImport]
+[ComVisible(true)]
+[Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IDirect3DDxgiInterfaceAccess
+{
+    IntPtr GetInterface([In] ref Guid iid);
+};

--- a/src/Greenshot/Native/DirectX/IGraphicsCaptureItemInterop.cs
+++ b/src/Greenshot/Native/DirectX/IGraphicsCaptureItemInterop.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Greenshot.Native.DirectX;
+
+/// <summary>
+/// Provides methods for creating graphics capture items for a specified window or monitor.
+/// </summary>
+/// <remarks>This interface is used to interact with graphics capture items in a COM environment. It allows the
+/// creation of capture items based on either a window handle or a monitor handle, enabling applications to capture
+/// graphics content from specific sources.</remarks>
+[ComImport]
+[ComVisible(true)]
+[Guid("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IGraphicsCaptureItemInterop
+{
+    IntPtr CreateForWindow([In] IntPtr window, [In] ref Guid iid);
+    IntPtr CreateForMonitor([In] IntPtr hMonitor, [In] ref Guid iid);
+}

--- a/src/Greenshot/Native/WindowsGraphicsCaptureInterop.cs
+++ b/src/Greenshot/Native/WindowsGraphicsCaptureInterop.cs
@@ -1,0 +1,394 @@
+﻿/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Greenshot.Native.DirectX;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace Greenshot.Native
+{
+    /// <summary>
+    /// Provides static methods for capturing the visual content of windows and monitors via Windows Graphics Capture API
+    /// Utilizing Direct3D 11 for high-performance access to the captured frames.
+    /// </summary>
+    internal partial class WindowsGraphicsCaptureInterop
+    {
+        // Constants
+        private const int D3D11_SDK_VERSION = 7;
+        private const int D3D_DRIVER_TYPE_HARDWARE = 1;
+        private const int D3D11_CREATE_DEVICE_BGRA_SUPPORT = 0x20;
+
+        /// <summary>
+        /// Creates a Direct3D 11 device and its associated device context for hardware rendering with BGRA support.
+        /// </summary>
+        /// <param name="device">When this method returns, contains the created ID3D11Device instance representing the Direct3D device.</param>
+        /// <param name="context">When this method returns, contains the created ID3D11DeviceContext instance used to issue rendering commands.</param>
+        public static void CreateD3D11Device(out ID3D11Device device, out ID3D11DeviceContext context)
+        {
+            int hr = D3D11CreateDevice(
+                IntPtr.Zero,
+                D3D_DRIVER_TYPE_HARDWARE,
+                IntPtr.Zero,
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                null,
+                0,
+                D3D11_SDK_VERSION,
+                out device,
+                out _,
+                out context);
+
+            if (hr != 0) Marshal.ThrowExceptionForHR(hr);
+        }
+
+        /// <summary>
+        /// The GUID representing the GraphicsCaptureItem interface for interop operations.
+        /// </summary>
+        private static readonly Guid GraphicsCaptureItemGuid = new Guid("79C3F95B-31F7-4EC2-A464-632EF5D30760");
+
+        /// <summary>
+        /// Creates a new instance of a GraphicsCaptureItem that represents the specified window, enabling capture of
+        /// its visual content.
+        /// </summary>
+        /// <remarks>The caller must ensure that the window handle is valid and that the application has
+        /// the necessary permissions to capture the window's content. This method is typically used for screen capture
+        /// scenarios involving specific windows.</remarks>
+        /// <param name="window">The handle to the window for which the capture item is created. Must be a valid window handle.</param>
+        /// <returns>A GraphicsCaptureItem that corresponds to the specified window, allowing its content to be captured.</returns>
+        public static GraphicsCaptureItem CreateCaptureItemForWindow(IntPtr window)
+        {
+            var factory = WindowsRuntimeMarshal.GetActivationFactory(typeof(GraphicsCaptureItem));
+            var interop = (IGraphicsCaptureItemInterop)factory;
+            var itemPointer = interop.CreateForWindow(window, GraphicsCaptureItemGuid);
+            var item = Marshal.GetObjectForIUnknown(itemPointer) as GraphicsCaptureItem;
+            Marshal.Release(itemPointer);
+            return item;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a GraphicsCaptureItem that represents the specified monitor.
+        /// </summary>
+        /// <remarks>This method requires that the monitor handle is valid and accessible. Ensure that the
+        /// application has the necessary permissions to capture the monitor's content.</remarks>
+        /// <param name="hMonitor">The handle to the monitor for which the capture item is created. Must be a valid monitor handle obtained
+        /// from the system.</param>
+        /// <returns>A GraphicsCaptureItem that represents the specified monitor. Returns null if the creation fails.</returns>
+        public static GraphicsCaptureItem CreateCaptureItemForMonitor(IntPtr hMonitor)
+        {
+            var factory = WindowsRuntimeMarshal.GetActivationFactory(typeof(GraphicsCaptureItem));
+            var interop = (IGraphicsCaptureItemInterop)factory;
+            var itemPointer = interop.CreateForMonitor(hMonitor, GraphicsCaptureItemGuid);
+            var item = Marshal.GetObjectForIUnknown(itemPointer) as GraphicsCaptureItem;
+            Marshal.Release(itemPointer);
+            return item;
+        }
+
+        /// <summary>
+        /// Creates a Direct3D 11 device from an existing DXGI device handle.
+        /// </summary>
+        /// <remarks>This method enables integration between Direct3D 11 and DXGI by allowing the creation
+        /// of a Direct3D 11 device from an existing DXGI device. Ensure that the DXGI device is properly initialized
+        /// before calling this method. The created device can be used for resource sharing and interoperability
+        /// scenarios.</remarks>
+        /// <param name="dxgiDevice">A handle to the DXGI device from which the Direct3D 11 device will be created. Must be a valid and
+        /// initialized DXGI device.</param>
+        /// <param name="graphicsDevice">When the method returns, contains the handle to the newly created Direct3D 11 device.</param>
+        /// <returns>A value of zero if the operation succeeds; otherwise, an error code indicating the reason for failure.</returns>
+        [DllImport("d3d11.dll", EntryPoint = "CreateDirect3D11DeviceFromDXGIDevice", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+        private static extern UInt32 CreateDirect3D11DeviceFromDXGIDevice(IntPtr dxgiDevice, out IntPtr graphicsDevice);
+
+        [DllImport("d3d11.dll", CallingConvention = CallingConvention.StdCall)]
+        private static extern int D3D11CreateDevice(
+            IntPtr pAdapter,
+            int driverType,
+            IntPtr software,
+            int flags,
+            IntPtr[] pFeatureLevels,
+            int featureLevels,
+            int sdkVersion,
+            out ID3D11Device ppDevice,
+            out int pFeatureLevel,
+            out ID3D11DeviceContext ppImmediateContext);
+
+        /// <summary>
+        /// Creates a new IDirect3DDevice instance from the specified ID3D11Device.
+        /// </summary>
+        /// <remarks>This method internally marshals the ID3D11Device to a DXGI device and uses it to
+        /// create a Direct3D device. If the operation fails, an exception is thrown. Ensure that the provided device is
+        /// valid before calling this method.</remarks>
+        /// <param name="d3dDevice">The ID3D11Device to convert. This parameter cannot be null and must be properly initialized.</param>
+        /// <returns>An IDirect3DDevice representing the Direct3D device created from the provided ID3D11Device. Returns null if
+        /// the creation fails.</returns>
+        internal static IDirect3DDevice CreateID3DDeviceFromD3D11Device(ID3D11Device d3dDevice)
+        {
+            IDirect3DDevice device = null;
+            var dxgiDevice = (IDXGIDevice)d3dDevice;
+            IntPtr pDxgiDevice = Marshal.GetComInterfaceForObject(dxgiDevice, typeof(IDXGIDevice));
+
+            try
+            {
+                var hr = CreateDirect3D11DeviceFromDXGIDevice(pDxgiDevice, out IntPtr pUnknown);
+                if (hr == 0)
+                {
+                    device = Marshal.GetObjectForIUnknown(pUnknown) as IDirect3DDevice;
+                    Marshal.Release(pUnknown);
+                }
+                else
+                {
+                    Marshal.ThrowExceptionForHR((int)hr);
+                }
+                return device;
+            }
+            finally
+            {
+                Marshal.Release(pDxgiDevice);
+            }
+        }
+
+        private static readonly Guid IID_ID3D11Texture2D = new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+        /// <summary>
+        /// Creates a new ID3D11Texture2D instance from the specified Direct3D surface.
+        /// </summary>
+        /// <remarks>This method retrieves the underlying ID3D11Texture2D interface from the given surface.
+        /// Ensure that the surface supports ID3D11Texture2D to avoid runtime errors.</remarks>
+        /// <param name="surface">The IDirect3DSurface from which to create the texture. Must be a valid Direct3D surface compatible with ID3D11Texture2D.</param>
+        /// <returns>An ID3D11Texture2D object representing the texture created from the provided surface.</returns>
+        private static ID3D11Texture2D CreateTexture2DFromID3DSurface(IDirect3DSurface surface)
+        {
+            var access = (IDirect3DDxgiInterfaceAccess)surface;
+            var d3dPointer = access.GetInterface(IID_ID3D11Texture2D);
+            var d3dSurface = (ID3D11Texture2D)Marshal.GetObjectForIUnknown(d3dPointer);
+            Marshal.Release(d3dPointer);
+            return d3dSurface;
+        }
+
+        /// <summary>
+        /// Transforms a Direct3D 11 texture into a .NET Bitmap object in 32bpp ARGB format.
+        /// </summary>
+        /// <param name="texture">The Direct3D 11 texture to be converted. Must be a valid ID3D11Texture2D instance.</param>
+        /// <param name="device">The Direct3D 11 device used to create a staging texture for data transfer.</param>
+        /// <param name="context">The Direct3D 11 device context used to copy and map the texture data.</param>
+        /// <returns>A Bitmap containing the pixel data from the specified texture. The Bitmap is formatted as 32bpp ARGB.</returns>
+        private static unsafe Bitmap TransformTextureToBitmap(ID3D11Texture2D texture, ID3D11Device device, ID3D11DeviceContext context)
+        {
+            D3D11_TEXTURE2D_DESC desc;
+            texture.GetDesc(out desc);
+
+            var width = desc.Width;
+            var height = desc.Height;
+            long bytesPerRow = (long)width * 4;
+
+            var stagingDesc = new D3D11_TEXTURE2D_DESC
+            {
+                Width = width,
+                Height = height,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = desc.Format,
+                SampleDesc = new DXGI_SAMPLE_DESC { Count = 1, Quality = 0 },
+                Usage = D3D11_USAGE.D3D11_USAGE_STAGING,
+                BindFlags = 0,
+                CPUAccessFlags = D3D11_CPU_ACCESS_FLAG.D3D11_CPU_ACCESS_READ,
+                MiscFlags = 0
+            };
+
+            device.CreateTexture2D(ref stagingDesc, IntPtr.Zero, out var textureCopy);
+
+            try
+            {
+                context.CopyResource(textureCopy, texture);
+
+                // Test HRESULT of Map
+                int hr = context.Map(textureCopy, 0, D3D11_MAP.D3D11_MAP_READ, 0, out var mappedResource);
+                if (hr != 0) Marshal.ThrowExceptionForHR(hr);
+
+                try
+                {
+                    Bitmap bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+                    BitmapData bmpData = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
+
+                    byte* sourcePtr = (byte*)mappedResource.pData;
+                    byte* destPtr = (byte*)bmpData.Scan0;
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        // Use Buffer.MemoryCopy for fast, safe unmanaged copy
+                        Buffer.MemoryCopy(sourcePtr, destPtr, bytesPerRow, bytesPerRow);
+
+                        sourcePtr += mappedResource.RowPitch;
+                        destPtr += bmpData.Stride;
+                    }
+
+                    bitmap.UnlockBits(bmpData);
+                    return bitmap;
+                }
+                finally
+                {
+                    context.Unmap(textureCopy, 0);
+                }
+            }
+            finally
+            {
+                if (textureCopy != null) Marshal.ReleaseComObject(textureCopy);
+            }
+        }
+
+        /// <summary>
+        /// Captures the visual content of the specified window and returns it as a Bitmap image.
+        /// </summary>
+        /// <remarks>This method uses Direct3D 11 to capture the window's content.
+        /// The window must be visible and not minimized for accurate results.
+        /// The caller is responsible for disposing the returned Bitmap when it is no longer needed.
+        /// </remarks>
+        /// <param name="window">The handle to the window whose content is to be captured. Must be a valid window handle; otherwise, the capture may fail.</param>
+        /// <returns>A Bitmap object containing the captured image of the specified window. Returns null if the capture operation fails.</returns>
+        public static Bitmap CaptureWindowToBitmap(IntPtr window)
+        {
+            CreateD3D11Device(out var device, out var context);
+
+            try
+            {
+                var texture = CaptureWindowToTexture2D(window, device);
+
+                try
+                {
+                    return TransformTextureToBitmap(texture, device, context);
+                }
+                finally
+                {
+                    if (texture != null) Marshal.ReleaseComObject(texture);
+                }
+            }
+            finally
+            {
+                if (context != null) Marshal.ReleaseComObject(context);
+                if (device != null) Marshal.ReleaseComObject(device);
+            }
+        }
+
+        /// <summary>
+        /// Captures the image of the specified monitor and returns it as a Bitmap object.
+        /// </summary>
+        /// <remarks>This method uses Direct3D 11 to perform the capture. All COM resources are released
+        /// after the operation to prevent memory leaks. Ensure that the monitor handle is valid and accessible before
+        /// calling this method.</remarks>
+        /// <param name="hMonitor">A handle to the monitor to capture. Must be a valid monitor handle obtained from the system.</param>
+        /// <returns>A Bitmap containing the captured image of the monitor. Returns null if the capture operation fails.</returns>
+        public static Bitmap CaptureMonitorToBitmap(IntPtr hMonitor)
+        {
+            CreateD3D11Device(out var device, out var context);
+
+            try
+            {
+                var texture = CaptureMonitorToTexture2D(hMonitor, device);
+                try
+                {
+                    return TransformTextureToBitmap(texture, device, context);
+                }
+                finally
+                {
+                    if (texture != null) Marshal.ReleaseComObject(texture);
+                }
+            }
+            finally
+            {
+                if (context != null) Marshal.ReleaseComObject(context);
+                if (device != null) Marshal.ReleaseComObject(device);
+            }
+        }
+
+        /// <summary>
+        /// Captures the visual content of the specified window and returns it as a Direct3D 11 texture.
+        /// </summary>
+        /// <remarks>The capture excludes the cursor from the resulting texture. The method creates a
+        /// frame pool and capture session to obtain the window's content. Ensure that the provided window handle and
+        /// device are valid to avoid errors during capture.</remarks>
+        /// <param name="window">The handle of the window to capture. Must be a valid window handle.</param>
+        /// <param name="d3d11Device">The Direct3D 11 device used to create the resulting texture. Must be a valid ID3D11Device instance.</param>
+        /// <returns>An ID3D11Texture2D containing the captured content of the specified window.</returns>
+        private static ID3D11Texture2D CaptureWindowToTexture2D(IntPtr window, ID3D11Device d3d11Device)
+        {
+            var captureItem = CreateCaptureItemForWindow(window);
+            var device = CreateID3DDeviceFromD3D11Device(d3d11Device);
+
+            using var framePool = Direct3D11CaptureFramePool.Create(device, DirectXPixelFormat.B8G8R8A8UIntNormalized, 1, captureItem.Size);
+            var session = framePool.CreateCaptureSession(captureItem);
+
+            // The following should be false, but depends on the Windows SDK Contract version if it's available or not
+            //session.IsBorderRequired = false;
+
+            // We do not want to have the cursor in the capture, as we do this separately.
+            session.IsCursorCaptureEnabled = false;
+
+            session.StartCapture();
+
+            Direct3D11CaptureFrame frameTemp = null;
+            while (frameTemp == null)
+            {
+                frameTemp = framePool.TryGetNextFrame();
+            }
+
+            using var frame = frameTemp;
+            return CreateTexture2DFromID3DSurface(frame.Surface);
+        }
+
+        /// <summary>
+        /// Captures the visual content of the specified monitor and returns it as a Direct3D 11 2D texture.
+        /// </summary>
+        /// <remarks>The capture excludes the mouse cursor. Ensure that the monitor handle and Direct3D
+        /// device are valid before calling this method. The method blocks until a frame is available.</remarks>
+        /// <param name="hMonitor">The handle to the monitor to capture. Must be a valid monitor handle obtained from the operating system.</param>
+        /// <param name="d3d11Device">The Direct3D 11 device used to create the resulting texture. Must be initialized and valid.</param>
+        /// <returns>An ID3D11Texture2D containing the captured image of the monitor. The texture can be used for rendering or
+        /// further processing.</returns>
+        private static ID3D11Texture2D CaptureMonitorToTexture2D(IntPtr hMonitor, ID3D11Device d3d11Device)
+        {
+            var captureItem = CreateCaptureItemForMonitor(hMonitor);
+            var device = CreateID3DDeviceFromD3D11Device(d3d11Device);
+
+            using var framePool = Direct3D11CaptureFramePool.Create(device, DirectXPixelFormat.B8G8R8A8UIntNormalized, 1, captureItem.Size);
+            var session = framePool.CreateCaptureSession(captureItem);
+
+            // The following should be false, but depends on the Windows SDK Contract version if it's available or not
+            //session.IsBorderRequired = false;
+
+            // We do not want to have the cursor in the capture, as we do this separately.
+            session.IsCursorCaptureEnabled = false;
+
+            session.StartCapture();
+
+            Direct3D11CaptureFrame frameTemp = null;
+            while (frameTemp == null)
+            {
+                frameTemp = framePool.TryGetNextFrame();
+            }
+
+            using var frame = frameTemp;
+            return CreateTexture2DFromID3DSurface(frame.Surface);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds WindowsGraphicsCapture functionality to capture the Window (and screen, but this is not yet included) as a Beta Test feature.

WGC is a relative new feature in Windows, arrived with Windows 10, made to capture Windows and screens with the latest technologies. This should work with HDR, high DPI and also with games, but I didn't put it through extensive tests... Which is why we put it behind a feature toggle.

WGC captures the window contents from the composition engine, sometimes it takes a bit longer if there are no changes, so we need to monitor this. I also noticed that it uses transparency, let's see how that works.

Anyway, to make this work on .NET 10 would be easy, unfortunately we are on .NET framework, so I had to use some tricks and DirectX code, including SharpDx (no longer maintained) as a dependency would not be very satisfactory, so I had to create the needed interop classes myself.

For now I only enabled Window capture, due to limited time. The screen capture will need to be added later, as this is monitor based and not 100% in line with the current GDI (bitblt) capture.