### PR TITLE
Add a remove transparency feature to the editor

### DIFF
--- a/src/Greenshot.Base/Effects/RemoveTransparencyEffect.cs
+++ b/src/Greenshot.Base/Effects/RemoveTransparencyEffect.cs
@@ -1,0 +1,67 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ * 
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using Greenshot.Base.Core;
+
+namespace Greenshot.Base.Effects
+{
+    /// <summary>
+    /// RemoveTransparencyEffect - Removes transparency from images and replaces it with a solid color
+    /// </summary>
+    public class RemoveTransparencyEffect : IEffect
+    {
+        public RemoveTransparencyEffect()
+        {
+            Reset();
+        }
+
+        public Color Color { get; set; }
+
+        public void Reset()
+        {
+            Color = Color.White;
+        }
+
+        public Image Apply(Image sourceImage, Matrix matrix)
+        {
+            // Only process if the image has an alpha channel
+            if (!Image.IsAlphaPixelFormat(sourceImage.PixelFormat))
+            {
+                return null;
+            }
+
+            // Create a new bitmap without alpha channel
+            Bitmap newBitmap = new Bitmap(sourceImage.Width, sourceImage.Height, PixelFormat.Format24bppRgb);
+            
+            using (Graphics graphics = Graphics.FromImage(newBitmap))
+            {
+                graphics.Clear(Color);
+                graphics.CompositingMode = CompositingMode.SourceOver;
+                graphics.DrawImage(sourceImage, 0, 0, sourceImage.Width, sourceImage.Height);
+            }
+
+            return newBitmap;
+        }
+    }
+}

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
@@ -81,6 +81,7 @@ namespace Greenshot.Editor.Forms
 			this.tornEdgesToolStripMenuItem = new GreenshotToolStripMenuItem();
 			this.grayscaleToolStripMenuItem = new GreenshotToolStripMenuItem();
 			this.invertToolStripMenuItem = new GreenshotToolStripMenuItem();
+			this.removeTransparencyToolStripMenuItem = new GreenshotToolStripMenuItem();
 			this.btnResize = new GreenshotToolStripButton();
 			this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
 			this.btnCrop = new GreenshotToolStripButton();
@@ -491,7 +492,8 @@ namespace Greenshot.Editor.Forms
 									this.addDropshadowToolStripMenuItem,
 									this.tornEdgesToolStripMenuItem,
 									this.grayscaleToolStripMenuItem,
-									this.invertToolStripMenuItem});
+									this.invertToolStripMenuItem,
+									this.removeTransparencyToolStripMenuItem});
 			this.toolStripSplitButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripSplitButton1.Image")));
 			this.toolStripSplitButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.toolStripSplitButton1.LanguageKey = "editor_effects";
@@ -528,6 +530,12 @@ namespace Greenshot.Editor.Forms
 			this.invertToolStripMenuItem.LanguageKey = "editor_invert";
 			this.invertToolStripMenuItem.Name = "invertToolStripMenuItem";
 			this.invertToolStripMenuItem.Click += new System.EventHandler(this.InvertToolStripMenuItemClick);
+			// 
+			// removeTransparencyToolStripMenuItem
+			// 
+			this.removeTransparencyToolStripMenuItem.LanguageKey = "editor_remove_transparency";
+			this.removeTransparencyToolStripMenuItem.Name = "removeTransparencyToolStripMenuItem";
+			this.removeTransparencyToolStripMenuItem.Click += new System.EventHandler(this.RemoveTransparencyToolStripMenuItemClick);
 			// 
 			// btnResize
 			// 
@@ -1915,6 +1923,7 @@ namespace Greenshot.Editor.Forms
 		private GreenshotToolStripMenuItem alignTopToolStripMenuItem;
 		private BindableToolStripDropDownButton textVerticalAlignmentButton;
 		private GreenshotToolStripMenuItem invertToolStripMenuItem;
+		private GreenshotToolStripMenuItem removeTransparencyToolStripMenuItem;
 		private GreenshotToolStripButton btnResize;
 		private GreenshotToolStripMenuItem grayscaleToolStripMenuItem;
 		private GreenshotToolStripButton rotateCcwToolstripButton;

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -1434,6 +1434,12 @@ namespace Greenshot.Editor.Forms
             UpdateClipboardSurfaceDependencies();
             UpdateUndoRedoSurfaceDependencies();
 
+            // Show/hide remove transparency menu item based on whether image has transparency
+            if (_surface?.Image != null)
+            {
+                removeTransparencyToolStripMenuItem.Visible = Image.IsAlphaPixelFormat(_surface.Image.PixelFormat);
+            }
+
             // en/disablearrage controls depending on hierarchy of selected elements
             bool actionAllowedForSelection = _surface.HasSelectedElements && !_controlsDisabledDueToConfirmable;
             bool push = actionAllowedForSelection && _surface.CanPushSelectionDown();
@@ -1855,6 +1861,24 @@ namespace Greenshot.Editor.Forms
         {
             _surface.ApplyBitmapEffect(new InvertEffect());
             UpdateUndoRedoSurfaceDependencies();
+        }
+
+        private void RemoveTransparencyToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            var colorDialog = new ColorDialog
+            {
+                Color = Color.White
+            };
+            
+            if (colorDialog.ShowDialog(this) == DialogResult.OK)
+            {
+                var removeTransparencyEffect = new RemoveTransparencyEffect
+                {
+                    Color = colorDialog.Color
+                };
+                _surface.ApplyBitmapEffect(removeTransparencyEffect);
+                UpdateUndoRedoSurfaceDependencies();
+            }
         }
 
         private void ImageEditorFormResize(object sender, EventArgs e)

--- a/src/Greenshot/Languages/language-ar-SY.xml
+++ b/src/Greenshot/Languages/language-ar-SY.xml
@@ -99,6 +99,7 @@
 		<resource name="editor_pixel_size">حجم البيكسل</resource>
 		<resource name="editor_preview_quality">معاينة الجودة</resource>
 		<resource name="editor_print">اطبع</resource>
+		<resource name="editor_remove_transparency">إزالة الشفافية</resource>
 		<resource name="editor_save">احفظ</resource>
 		<resource name="editor_save_objects">حفظ العنصر في ملف</resource>
 		<resource name="editor_saveas">احفظ باسم...</resource>

--- a/src/Greenshot/Languages/language-ca-CA.xml
+++ b/src/Greenshot/Languages/language-ca-CA.xml
@@ -135,6 +135,7 @@ Abans de crear un nou informe d'error, us agrairem que comproveu que l'error no 
 		<resource name="editor_pixel_size">Mida del pixel</resource>
 		<resource name="editor_preview_quality">Qualitat de previsualització</resource>
 		<resource name="editor_print">Imprimeix</resource>
+		<resource name="editor_remove_transparency">Eliminar transparència</resource>
 		<resource name="editor_redo">Refés {0}</resource>
 		<resource name="editor_resetsize">Reinicia la mida</resource>
 		<resource name="editor_resize_percent">Percentatge</resource>

--- a/src/Greenshot/Languages/language-cs-CZ.xml
+++ b/src/Greenshot/Languages/language-cs-CZ.xml
@@ -137,6 +137,7 @@ Také bychom velmi ocenili, kdybyste zkontrolovali, zda tato chyba již není ev
 		<resource name="editor_pixel_size">Velikost pixelu</resource>
 		<resource name="editor_preview_quality">Kvalita náhledu</resource>
 		<resource name="editor_print">Tisk</resource>
+		<resource name="editor_remove_transparency">Odstranit průhlednost</resource>
 		<resource name="editor_redo">Znovu {0}</resource>
 		<resource name="editor_resetsize">Obnovit velikost</resource>
 		<resource name="editor_resize_percent">Procent</resource>

--- a/src/Greenshot/Languages/language-da-DK.xml
+++ b/src/Greenshot/Languages/language-da-DK.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Dansk" ietf="da-DK" version="0.8.0" languagegroup="1">
   <resources>
 	<!--    
@@ -180,6 +180,7 @@ Detaljer om GNU General Public License:
 	<resource name="editor_print">
 		Udskriv
 	</resource>
+		<resource name="editor_remove_transparency">Fjern gennemsigtighed</resource>
 	<resource name="help_title">
 		Greenshot hjælp
 	</resource>

--- a/src/Greenshot/Languages/language-de-DE.xml
+++ b/src/Greenshot/Languages/language-de-DE.xml
@@ -140,6 +140,7 @@ schnell zu finden. Vielen Dank :)</resource>
 		<resource name="editor_pixel_size">Pixelgröße</resource>
 		<resource name="editor_preview_quality">Vorschauqualität</resource>
 		<resource name="editor_print">Drucken</resource>
+		<resource name="editor_remove_transparency">Transparenz entfernen</resource>
 		<resource name="editor_redo">Wiederherstellen {0}</resource>
 		<resource name="editor_resetsize">Größe zurücksetzen</resource>
 		<resource name="editor_resize_percent">Prozent</resource>

--- a/src/Greenshot/Languages/language-de-x-franconia.xml
+++ b/src/Greenshot/Languages/language-de-x-franconia.xml
@@ -131,6 +131,7 @@ Dangschee, wassd scho :)</resource>
 		<resource name="editor_pixel_size">Bixlgröß</resource>
 		<resource name="editor_preview_quality">Vorschaugwalidäd</resource>
 		<resource name="editor_print">Druggn</resource>
+		<resource name="editor_remove_transparency">Dransbarenz wech machn</resource>
 		<resource name="editor_redo">Widderherschdelln {0}</resource>
 		<resource name="editor_resetsize">Größe zrüggsedzn</resource>
 		<resource name="editor_rotateccw">Gechern Uhrzeichersinn drehn</resource>

--- a/src/Greenshot/Languages/language-el-GR.xml
+++ b/src/Greenshot/Languages/language-el-GR.xml
@@ -140,6 +140,7 @@
 		<resource name="editor_pixel_size">Μέγεθος εικονοστοιχείων</resource>
 		<resource name="editor_preview_quality">Ποιότητα προεπισκόπησης</resource>
 		<resource name="editor_print">Εκτύπωση</resource>
+		<resource name="editor_remove_transparency">Κατάργηση διαφάνειας</resource>
 		<resource name="editor_redo">Ακύρωση Αναίρεσης {0}</resource>
 		<resource name="editor_resetsize">Επαναφορά μεγέθους</resource>
 		<resource name="editor_resize_percent">Επί τοις εκατό</resource>

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -141,6 +141,7 @@ Also, we would highly appreciate if you checked whether a tracker item already e
 		<resource name="editor_pixel_size">Pixel size</resource>
 		<resource name="editor_preview_quality">Preview quality</resource>
 		<resource name="editor_print">Print</resource>
+		<resource name="editor_remove_transparency">Remove transparency</resource>
 		<resource name="editor_redo">Redo {0}</resource>
 		<resource name="editor_resetsize">Reset size</resource>
 		<resource name="editor_resize_percent">Percent</resource>

--- a/src/Greenshot/Languages/language-es-ES.xml
+++ b/src/Greenshot/Languages/language-es-ES.xml
@@ -124,6 +124,7 @@ Antes de crear un nuevo informe de error, te agradeceríamos que comprobaras que
 		<resource name="editor_pixel_size">Tamaño de pixel</resource>
 		<resource name="editor_preview_quality">Calidad de previsualización</resource>
 		<resource name="editor_print">Imprimir</resource>
+		<resource name="editor_remove_transparency">Eliminar transparencia</resource>
 		<resource name="editor_redo">Rehacer {0}</resource>
 		<resource name="editor_resetsize">Reiniciar tamaño</resource>
 		<resource name="editor_rotateccw">Rotar en sentido antihorario</resource>

--- a/src/Greenshot/Languages/language-et-EE.xml
+++ b/src/Greenshot/Languages/language-et-EE.xml
@@ -139,6 +139,7 @@ Me oleksime väga tänulik, kui te enne kontrolliksite, ega sellest veast pole j
 		<resource name="editor_pixel_size">Piksli suurus</resource>
 		<resource name="editor_preview_quality">Eelvaate kvaliteet</resource>
 		<resource name="editor_print">Printige</resource>
+		<resource name="editor_remove_transparency">Eemalda läbipaistvus</resource>
 		<resource name="editor_redo">Tehke uuesti {0}</resource>
 		<resource name="editor_resetsize">Taastage normaalne suurus</resource>
 		<resource name="editor_resize_percent">Protsent</resource>

--- a/src/Greenshot/Languages/language-fa-IR.xml
+++ b/src/Greenshot/Languages/language-fa-IR.xml
@@ -112,6 +112,7 @@ Could not save Greenshot's configuration file. Please check access permissions f
 		<resource name="editor_pixel_size">اندازه پیکسل</resource>
 		<resource name="editor_preview_quality">کیفیت پیشنمایش</resource>
 		<resource name="editor_print">چاپ</resource>
+		<resource name="editor_remove_transparency">حذف شفافیت</resource>
 		<resource name="editor_save">ذخیره</resource>
 		<resource name="editor_save_objects">ذخیره شیی در فایل</resource>
 		<resource name="editor_saveas">...ذخیره با نام</resource>

--- a/src/Greenshot/Languages/language-fi-FI.xml
+++ b/src/Greenshot/Languages/language-fi-FI.xml
@@ -99,6 +99,7 @@ Olisi myös hyvä jos voisit tarkistaa onko virhe jo raportoitu aikaisemmin (voi
 		<resource name="editor_pixel_size">Pixel size</resource>
 		<resource name="editor_preview_quality">Esikatselun laatu</resource>
 		<resource name="editor_print">Tulosta</resource>
+		<resource name="editor_remove_transparency">Poista läpinäkyvyys</resource>
 		<resource name="editor_save">Tallenna</resource>
 		<resource name="editor_save_objects">Tallenna objektit tiedostoon</resource>
 		<resource name="editor_saveas">Tallenna nimellä...</resource>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -141,6 +141,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_pixel_size">Taille de pixel</resource>
 		<resource name="editor_preview_quality">Qualité de prévisualisation</resource>
 		<resource name="editor_print">Imprimer</resource>
+		<resource name="editor_remove_transparency">Supprimer la transparence</resource>
 		<resource name="editor_redo">Rétablir {0}</resource>
 		<resource name="editor_resetsize">Réinitialiser la taille</resource>
 		<resource name="editor_resize">Redimensionner (Z)</resource>

--- a/src/Greenshot/Languages/language-fr-QC.xml
+++ b/src/Greenshot/Languages/language-fr-QC.xml
@@ -120,6 +120,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_pixel_size">Taille de pixel</resource>
 		<resource name="editor_preview_quality">Qualité des prévisualisations</resource>
 		<resource name="editor_print">Imprimer</resource>
+		<resource name="editor_remove_transparency">Supprimer la transparence</resource>
 		<resource name="editor_redo">Refaire {0}</resource>
 		<resource name="editor_resetsize">Remettre à zéro la taille</resource>
 		<resource name="editor_rotateccw">Tourner en sens anti-horaire</resource>

--- a/src/Greenshot/Languages/language-he-IL.xml
+++ b/src/Greenshot/Languages/language-he-IL.xml
@@ -100,6 +100,7 @@ Details about the GNU General Public License:</resource>
 		<resource name="editor_pixel_size">גודל פיקסל</resource>
 		<resource name="editor_preview_quality">איכות תצוגה מקדימה</resource>
 		<resource name="editor_print">הדפסה</resource>
+		<resource name="editor_remove_transparency">הסר שקיפות</resource>
 		<resource name="editor_save">שמור</resource>
 		<resource name="editor_save_objects">שמור אובייקט לקובץ</resource>
 		<resource name="editor_saveas">...שמירה בשם</resource>

--- a/src/Greenshot/Languages/language-hu-HU.xml
+++ b/src/Greenshot/Languages/language-hu-HU.xml
@@ -100,6 +100,7 @@ Kérjük adjon összefoglaló leírást és csatoljon minden olyan információt
 		<resource name="editor_pixel_size">Pixel méret</resource>
 		<resource name="editor_preview_quality">Előnézet minősége</resource>
 		<resource name="editor_print">Nyomtatás</resource>
+		<resource name="editor_remove_transparency">Átlátszóság eltávolítása</resource>
 		<resource name="editor_save">Mentés</resource>
 		<resource name="editor_save_objects">Kijelölés mentése fájlba</resource>
 		<resource name="editor_saveas">Mentés másként</resource>

--- a/src/Greenshot/Languages/language-id-ID.xml
+++ b/src/Greenshot/Languages/language-id-ID.xml
@@ -140,6 +140,7 @@ Juga, kami sangat terbantu apabila anda mengecek laporan lain yang sama dengan k
 		<resource name="editor_pixel_size">Ukuran piksel</resource>
 		<resource name="editor_preview_quality">Kualitas pratayang</resource>
 		<resource name="editor_print">Cetak</resource>
+		<resource name="editor_remove_transparency">Hapus transparansi</resource>
 		<resource name="editor_redo">Ulang {0}</resource>
 		<resource name="editor_resetsize">Reset ukuran</resource>
 		<resource name="editor_resize">Ubah ukuran (Z)</resource>

--- a/src/Greenshot/Languages/language-it-IT.xml
+++ b/src/Greenshot/Languages/language-it-IT.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Italiano" ietf="it-IT" version="1.3.0" languagegroup="1">
     <resources>
         <resource name="about_bugs">Segnala eventuali bug a questo indirizzo</resource>
@@ -144,6 +144,7 @@ Controlla i permessi di accesso per '{0}'.</resource>
         <resource name="editor_pixel_size">Dimensioni pixel</resource>
         <resource name="editor_preview_quality">Qualità anteprima</resource>
         <resource name="editor_print">Stampa</resource>
+		<resource name="editor_remove_transparency">Rimuovi trasparenza</resource>
         <resource name="editor_redo">Ripeti azione {0}</resource>
         <resource name="editor_resetsize">Azzera dimensione</resource>
         <resource name="editor_resize_percent">Percentuale</resource>

--- a/src/Greenshot/Languages/language-ja-JP.xml
+++ b/src/Greenshot/Languages/language-ja-JP.xml
@@ -142,6 +142,7 @@ GNU General Public License の詳細:</resource>
 		<resource name="editor_pixel_size">ピクセル サイズ</resource>
 		<resource name="editor_preview_quality">プレビュー品質</resource>
 		<resource name="editor_print">印刷</resource>
+		<resource name="editor_remove_transparency">透明度を削除</resource>
 		<resource name="editor_redo">やり直し{0}</resource>
 		<resource name="editor_resetsize">サイズをリセット</resource>
 		<resource name="editor_resize">サイズ変更</resource>

--- a/src/Greenshot/Languages/language-kab-DZ.xml
+++ b/src/Greenshot/Languages/language-kab-DZ.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Taqbaylit" ietf="kab-DZ" version="1.2.0.58" languagegroup="1">
 	<resources>
 		<resource name="about_bugs">Azen ibugen ar</resource>
@@ -140,6 +140,7 @@ Rnu ɣur-s, nḥemmel aṭas ma yella tesneqdeḍ aneqqis igebren ugur-agi. (Tze
 		<resource name="editor_pixel_size">Teɣzu n upiksil</resource>
 		<resource name="editor_preview_quality">Taɣara n teskant</resource>
 		<resource name="editor_print">Siggez</resource>
+		<resource name="editor_remove_transparency">Kkes tanmislit</resource>
 		<resource name="editor_redo">Err-d {0}</resource>
 		<resource name="editor_resetsize">Wennez teɣzi</resource>
 		<resource name="editor_resize">Snifel tahri/teɣzi (Z)</resource>

--- a/src/Greenshot/Languages/language-ko-KR.xml
+++ b/src/Greenshot/Languages/language-ko-KR.xml
@@ -135,6 +135,7 @@ Also, we would highly appreciate if you checked whether a tracker item already e
 		<resource name="editor_pixel_size">화소 크기</resource>
 		<resource name="editor_preview_quality">미리보기 품질</resource>
 		<resource name="editor_print">인쇄</resource>
+		<resource name="editor_remove_transparency">투명도 제거</resource>
 		<resource name="editor_redo">재실행 {0}</resource>
 		<resource name="editor_resetsize">초기화 크기</resource>
 		<resource name="editor_resize_percent">백분율</resource>

--- a/src/Greenshot/Languages/language-lt-LT.xml
+++ b/src/Greenshot/Languages/language-lt-LT.xml
@@ -98,6 +98,7 @@ Dėkojame už pagalbą :)</resource>
 		<resource name="editor_pixel_size">Kvadratėlių dydis</resource>
 		<resource name="editor_preview_quality">Peržiūros kokybė</resource>
 		<resource name="editor_print">Spausdinti</resource>
+		<resource name="editor_remove_transparency">Pašalinti permatomumą</resource>
 		<resource name="editor_save">Išsaugoti</resource>
 		<resource name="editor_save_objects">Išsaugoti objektus į failą</resource>
 		<resource name="editor_saveas">Išsaugoti kaip...</resource>

--- a/src/Greenshot/Languages/language-lv-LV.xml
+++ b/src/Greenshot/Languages/language-lv-LV.xml
@@ -135,6 +135,7 @@ Mēs būtu Tev pateicīgi, ja Tu vispirms pārbaudītu, vai kāds cits jau nav z
 		<resource name="editor_pixel_size">Pikseļa izmērs</resource>
 		<resource name="editor_preview_quality">Priekšapskates kvalitāte</resource>
 		<resource name="editor_print">Drukāt</resource>
+		<resource name="editor_remove_transparency">Noņemt caurspīdīgumu</resource>
 		<resource name="editor_redo">Atcelt atsaukšanu {0}</resource>
 		<resource name="editor_resetsize">Atjaunot izmēru</resource>
 		<resource name="editor_resize_percent">Procenti</resource>

--- a/src/Greenshot/Languages/language-nl-NL.xml
+++ b/src/Greenshot/Languages/language-nl-NL.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Nederlands" ietf="nl-NL" version="1.0.4" languagegroup="1">
 	<resources>
 		<resource name="about_bugs">Meld problemen bij</resource>
@@ -137,6 +137,7 @@ Controleer ook even of dit probleem mogelijk al gemeld is! Gebruik de zoekfuncti
 		<resource name="editor_pixel_size">Pixelgrootte</resource>
 		<resource name="editor_preview_quality">Kwaliteit voorbeeld</resource>
 		<resource name="editor_print">Afdrukken</resource>
+		<resource name="editor_remove_transparency">Transparantie verwijderen</resource>
 		<resource name="editor_redo">Opnieuw {0}</resource>
 		<resource name="editor_resetsize">Afmetingen herstellen</resource>
 		<resource name="editor_resize_percent">Procent</resource>

--- a/src/Greenshot/Languages/language-nn-NO.xml
+++ b/src/Greenshot/Languages/language-nn-NO.xml
@@ -123,6 +123,7 @@ Me sett òg pris på om du ved hjelp av søkefunksjonen på sida kan sjekke om d
 		<resource name="editor_pixel_size">Pikselstorleik</resource>
 		<resource name="editor_preview_quality">Kvalitet på førehandssyning</resource>
 		<resource name="editor_print">Skriv ut</resource>
+		<resource name="editor_remove_transparency">Fjern gjennomsiktigheit</resource>
 		<resource name="editor_redo">Gjer om {0}</resource>
 		<resource name="editor_resetsize">Nullstill storleik</resource>
 		<resource name="editor_rotateccw">Roter mot klokka</resource>

--- a/src/Greenshot/Languages/language-pl-PL.xml
+++ b/src/Greenshot/Languages/language-pl-PL.xml
@@ -141,6 +141,7 @@ Będziemy wdzięczni, jeśli najpierw sprawdzisz, czy takie zdarzenie nie zosta�
 		<resource name="editor_pixel_size">Rozmiar piksela</resource>
 		<resource name="editor_preview_quality">Jakość podglądu</resource>
 		<resource name="editor_print">Drukuj</resource>
+		<resource name="editor_remove_transparency">Usuń przezroczystość</resource>
 		<resource name="editor_redo">Cofnij {0}</resource>
 		<resource name="editor_resetsize">Domyślny rozmiar</resource>
 		<resource name="editor_resize_percent">Procent</resource>

--- a/src/Greenshot/Languages/language-pt-BR.xml
+++ b/src/Greenshot/Languages/language-pt-BR.xml
@@ -125,6 +125,7 @@
 		<resource name="editor_pixel_size">Tamanho de Pixel</resource>
 		<resource name="editor_preview_quality">Qualidade do preview</resource>
 		<resource name="editor_print">Imprimir</resource>
+		<resource name="editor_remove_transparency">Remover transparência</resource>
 		<resource name="editor_save">Salvar</resource>
 		<resource name="editor_save_objects">Salvar objetos em arquivo...</resource>
 		<resource name="editor_saveas">Salvar como...</resource>

--- a/src/Greenshot/Languages/language-pt-PT.xml
+++ b/src/Greenshot/Languages/language-pt-PT.xml
@@ -136,6 +136,7 @@ Também apreciaremos muito se puder verificar se não existe já um relatório d
 		<resource name="editor_pixel_size">Tamanho de Pixel</resource>
 		<resource name="editor_preview_quality">Qualidade da pré-visualização</resource>
 		<resource name="editor_print">Imprimir</resource>
+		<resource name="editor_remove_transparency">Remover transparência</resource>
 		<resource name="editor_redo">Refazer {0}</resource>
 		<resource name="editor_resetsize">Repor tamanho</resource>
 		<resource name="editor_resize_percent">Percentagem</resource>

--- a/src/Greenshot/Languages/language-ro-RO.xml
+++ b/src/Greenshot/Languages/language-ro-RO.xml
@@ -180,6 +180,7 @@ Detalii despre licența GNU General Public License:
 	<resource name="editor_print">
 		Imprimă
 	</resource>
+		<resource name="editor_remove_transparency">Elimină transparența</resource>
 	<resource name="help_title">
 		Ajutor Greenshot
 	</resource>

--- a/src/Greenshot/Languages/language-ru-RU.xml
+++ b/src/Greenshot/Languages/language-ru-RU.xml
@@ -141,6 +141,7 @@ Greenshot поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ.�
 		<resource name="editor_pixel_size">Размер пикселя</resource>
 		<resource name="editor_preview_quality">Качество предосмотра</resource>
 		<resource name="editor_print">Печать</resource>
+		<resource name="editor_remove_transparency">Удалить прозрачность</resource>
 		<resource name="editor_redo">Повторить {0}</resource>
 		<resource name="editor_resetsize">Сброс размера</resource>
 		<resource name="editor_resize_percent">Процент</resource>

--- a/src/Greenshot/Languages/language-sk-SK.xml
+++ b/src/Greenshot/Languages/language-sk-SK.xml
@@ -123,6 +123,7 @@ Tiež by sme velmi ocenili, keby ste najskôr skontrolovali, či už neexistuje 
 		<resource name="editor_pixel_size">Veľkosť pixelu</resource>
 		<resource name="editor_preview_quality">Ukážka kvality</resource>
 		<resource name="editor_print">Tlač</resource>
+		<resource name="editor_remove_transparency">Odstrániť priehľadnosť</resource>
 		<resource name="editor_redo">Znova {0}</resource>
 		<resource name="editor_resetsize">Obnovit veľkosť</resource>
 		<resource name="editor_rotateccw">Otočiť proti smeru hodinových ručičiek</resource>

--- a/src/Greenshot/Languages/language-sl-SI.xml
+++ b/src/Greenshot/Languages/language-sl-SI.xml
@@ -121,6 +121,7 @@ Pred objavo preverite tudi ali je napaka že prijavlja s strani kakšnega drugeg
 		<resource name="editor_pixel_size">Velikost pixla</resource>
 		<resource name="editor_preview_quality">Kakovost predogleda</resource>
 		<resource name="editor_print">Tiskaj</resource>
+		<resource name="editor_remove_transparency">Odstrani prosojnost</resource>
 		<resource name="editor_redo">Ponovno uveljavi {0}</resource>
 		<resource name="editor_resetsize">Ponastavi velikost</resource>
 		<resource name="editor_rotateccw">Zavrti v nasprotni smeri ure</resource>

--- a/src/Greenshot/Languages/language-sr-RS.xml
+++ b/src/Greenshot/Languages/language-sr-RS.xml
@@ -121,6 +121,7 @@
 		<resource name="editor_pixel_size">Величина пиксела</resource>
 		<resource name="editor_preview_quality">Преглед квалитета</resource>
 		<resource name="editor_print">Одштампај</resource>
+		<resource name="editor_remove_transparency">Уклони провидност</resource>
 		<resource name="editor_redo">Понови {0}</resource>
 		<resource name="editor_resetsize">Поништи величину</resource>
 		<resource name="editor_rotateccw">Окрени улево</resource>

--- a/src/Greenshot/Languages/language-sv-SE.xml
+++ b/src/Greenshot/Languages/language-sv-SE.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Svenska" ietf="sv-SE" version="1.0.4" languagegroup="1">
 	<resources>
 		<resource name="about_bugs">Var vänlig att rapportera in fel till</resource>
@@ -141,6 +141,7 @@ Innan du skickar uppskattar vi verkligen om du kontrollerar om felet redan blivi
 		<resource name="editor_pixel_size">Pixelstorlek</resource>
 		<resource name="editor_preview_quality">Förhandskvalitet</resource>
 		<resource name="editor_print">Skriv ut</resource>
+		<resource name="editor_remove_transparency">Ta bort genomskinlighet</resource>
 		<resource name="editor_redo">Upprepa {0}</resource>
 		<resource name="editor_resetsize">Återställ storlek</resource>
 		<resource name="editor_resize_percent">Procent</resource>

--- a/src/Greenshot/Languages/language-tr-TR.xml
+++ b/src/Greenshot/Languages/language-tr-TR.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Turkish" ietf="tr-TR" version="1.0.2" languagegroup="6">
 	<resources>
 		<resource name="about_bugs">Hataları şu adrese bildirebilirsiniz:</resource>
@@ -140,6 +140,7 @@ Benzer bir hatanın daha önce bildirilip bildirilmediğini kontrol ederseniz ç
 		<resource name="editor_pixel_size">Piksel boyutu</resource>
 		<resource name="editor_preview_quality">Ön izleme kalitesi</resource>
 		<resource name="editor_print">Yazdır</resource>
+		<resource name="editor_remove_transparency">Saydamlığı kaldır</resource>
 		<resource name="editor_redo">Yeniden yap {0}</resource>
 		<resource name="editor_resetsize">Boyutu sıfırla</resource>
         <resource name="editor_resize_percent">Yüzde</resource>

--- a/src/Greenshot/Languages/language-uk-UA.xml
+++ b/src/Greenshot/Languages/language-uk-UA.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Українська" ietf="uk-UA" version="1.0.4" languagegroup="5">
 	<resources>
 		<resource name="about_bugs">Про помилки повідомляйте на</resource>
@@ -135,6 +135,7 @@ Greenshot постачається АБСОЛЮТНО БЕЗ ГАРАНТІЇ. �
 		<resource name="editor_pixel_size">Розмір пікселя</resource>
 		<resource name="editor_preview_quality">Якість перегляду</resource>
 		<resource name="editor_print">Друк</resource>
+		<resource name="editor_remove_transparency">Видалити прозорість</resource>
 		<resource name="editor_redo">Повторити {0}</resource>
 		<resource name="editor_resetsize">Скинути розмір</resource>
 		<resource name="editor_resize_percent">відсотків</resource>

--- a/src/Greenshot/Languages/language-vi-VN.xml
+++ b/src/Greenshot/Languages/language-vi-VN.xml
@@ -95,6 +95,7 @@
 		<resource name="editor_pixel_size">Cỡ điểm ảnh</resource>
 		<resource name="editor_preview_quality">Chất lượng ảnh xem trước</resource>
 		<resource name="editor_print">In</resource>
+		<resource name="editor_remove_transparency">Xóa độ trong suốt</resource>
 		<resource name="editor_save">Lưu</resource>
 		<resource name="editor_save_objects">Lưu đối tượng vào tệp</resource>
 		<resource name="editor_saveas">Lưu thành tệp...</resource>

--- a/src/Greenshot/Languages/language-zh-CN.xml
+++ b/src/Greenshot/Languages/language-zh-CN.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="简体中文" ietf="zh-CN" version="1.1.2.2572" languagegroup="1">
 	<resources>
 		<resource name="about_bugs">如果发现任何错误，请到以下网址报告</resource>
@@ -131,6 +131,7 @@
 		<resource name="editor_pixel_size">像素大小</resource>
 		<resource name="editor_preview_quality">预览质量</resource>
 		<resource name="editor_print">打印</resource>
+		<resource name="editor_remove_transparency">移除透明度</resource>
 		<resource name="editor_redo">重作{0}</resource>
 		<resource name="editor_resetsize">重置尺寸</resource>
 		<resource name="editor_rotateccw">逆时针旋转（Ctrl + ,）</resource>

--- a/src/Greenshot/Languages/language-zh-TW.xml
+++ b/src/Greenshot/Languages/language-zh-TW.xml
@@ -136,6 +136,7 @@ Greenshot 不對這個程式做任何擔保。這個程式是自由軟體，您�
 		<resource name="editor_pixel_size">像素大小</resource>
 		<resource name="editor_preview_quality">預覽品質</resource>
 		<resource name="editor_print">列印</resource>
+		<resource name="editor_remove_transparency">移除透明度</resource>
 		<resource name="editor_redo">重做 {0}</resource>
 		<resource name="editor_resetsize">重設大小</resource>
 		<resource name="editor_resize_percent">百分比</resource>


### PR DESCRIPTION
Especially with the Windows.Graphics.Capture captures this will start to make more sense, but I see a lot of images on the clipboard which also have this.