### PR TITLE
Fix for 2 UI drawing glitches (zoomer and starting drawing an annotation)

### DIFF
--- a/src/Greenshot.Editor/Drawing/DrawableContainer.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainer.cs
@@ -531,7 +531,7 @@ namespace Greenshot.Editor.Drawing
             Invalidate();
 
             // reset "workbench" rectangle to current bounds
-            _boundsAfterResize = new NativeRectFloat(_boundsBeforeResize.Left, _boundsBeforeResize.Top, x - _boundsAfterResize.Left, y - _boundsAfterResize.Top);
+            _boundsAfterResize = new NativeRectFloat(_boundsBeforeResize.Left, _boundsBeforeResize.Top, x - _boundsBeforeResize.Left, y - _boundsBeforeResize.Top);
 
             var scaleOptions = (this as IHaveScaleOptions)?.GetScaleOptions();
             _boundsAfterResize = ScaleHelper.Scale(_boundsAfterResize, x, y, GetAngleRoundProcessor(), scaleOptions);

--- a/src/Greenshot/Forms/CaptureForm.cs
+++ b/src/Greenshot/Forms/CaptureForm.cs
@@ -167,14 +167,18 @@ namespace Greenshot.Forms
 
             _currentForm = this;
 
-            // Enable the AnimatingForm
-            EnableAnimation = true;
-
             // clean up
             FormClosed += ClosedHandler;
             _capture = capture;
             _windows = windows;
             _captureMode = capture.CaptureDetails.CaptureMode;
+
+            // Set cursor location before enabling animations to avoid race condition
+            _cursorPos = WindowCapture.GetCursorLocationRelativeToScreenBounds();
+            _mouseMovePos = _cursorPos;
+
+            // Enable the AnimatingForm
+            EnableAnimation = true;
 
             //
             // The InitializeComponent() call is required for Windows Forms designer support.


### PR DESCRIPTION
2 small drawing fixes:

1. for the zoomer/cross initialization (it was briefly visible in the top-left screen)
2. for starting drawing arrows etc, drawing a line by clicking at a certain point showed a line until one started moving the mouse.