### PR TITLE
Stability fixes for 1.3

### DIFF
--- a/src/Greenshot.Base/Core/Capture.cs
+++ b/src/Greenshot.Base/Core/Capture.cs
@@ -113,7 +113,7 @@ namespace Greenshot.Base.Core
             set
             {
                 _cursor?.Dispose();
-                _cursor = (Icon) value.Clone();
+                _cursor = (Icon) value?.Clone();
             }
         }
 

--- a/src/Greenshot.Base/Core/ClipboardHelper.cs
+++ b/src/Greenshot.Base/Core/ClipboardHelper.cs
@@ -458,6 +458,11 @@ EndSelection:<<<<<<<4
                     fileData.Position = 0;
                     yield return (fileData, fileDescriptor.FileName);
                 }
+                else
+                {
+                    // Dispose the stream if it won't be yielded (empty or null length)
+                    fileData?.Dispose();
+                }
 
                 fileIndex++;
             }

--- a/src/Greenshot.Base/Core/EnvironmentInfo.cs
+++ b/src/Greenshot.Base/Core/EnvironmentInfo.cs
@@ -517,8 +517,14 @@ namespace Greenshot.Base.Core
 
                                     break;
                                 case 10:
-                                    string releaseId = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", "").ToString();
-                                    name = $"Windows 10 {releaseId}";
+                                    if (osVersion.Version.Build < 22000)
+                                    {
+                                        name = "Windows 10";
+                                    }
+                                    else
+                                    {
+                                        name = "Windows 11";
+                                    }
                                     break;
                             }
 

--- a/src/Greenshot.Base/Core/FileDescriptor.cs
+++ b/src/Greenshot.Base/Core/FileDescriptor.cs
@@ -52,11 +52,11 @@ namespace Greenshot.Base.Core
             //FileAttributes
             FileAttributes = (FileAttributes)reader.ReadUInt32();
             //CreationTime
-            CreationTime = new DateTime(1601, 1, 1).AddTicks(reader.ReadInt64());
+            CreationTime = ToRealDate(reader.ReadInt64());
             //LastAccessTime
-            LastAccessTime = new DateTime(1601, 1, 1).AddTicks(reader.ReadInt64());
+            LastAccessTime = ToRealDate(reader.ReadInt64());
             //LastWriteTime
-            LastWriteTime = new DateTime(1601, 1, 1).AddTicks(reader.ReadInt64());
+            LastWriteTime = ToRealDate(reader.ReadInt64());
             //FileSize
             FileSize = reader.ReadInt64();
             //FileName
@@ -71,6 +71,20 @@ namespace Greenshot.Base.Core
             }
 
             FileName = Encoding.Unicode.GetString(nameBytes, 0, i);
+        }
+
+        private DateTime ToRealDate(long ticks)
+        {
+            var result = new DateTime(1601, 1, 1);
+            try
+            {
+                result.AddTicks(ticks);
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+            return result;
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/DrawableContainer.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainer.cs
@@ -531,7 +531,7 @@ namespace Greenshot.Editor.Drawing
             Invalidate();
 
             // reset "workbench" rectangle to current bounds
-            _boundsAfterResize = new NativeRectFloat(_boundsBeforeResize.Left, _boundsBeforeResize.Top, x - _boundsAfterResize.Left, y - _boundsAfterResize.Top);
+            _boundsAfterResize = new NativeRectFloat(_boundsBeforeResize.Left, _boundsBeforeResize.Top, x - _boundsBeforeResize.Left, y - _boundsBeforeResize.Top);
 
             var scaleOptions = (this as IHaveScaleOptions)?.GetScaleOptions();
             _boundsAfterResize = ScaleHelper.Scale(_boundsAfterResize, x, y, GetAngleRoundProcessor(), scaleOptions);

--- a/src/Greenshot.Editor/Drawing/Surface.cs
+++ b/src/Greenshot.Editor/Drawing/Surface.cs
@@ -565,6 +565,11 @@ namespace Greenshot.Editor.Drawing
             if (disposing)
             {
                 LOG.Debug("Disposing surface!");
+                if (_image != null)
+                {
+                    _image.Dispose();
+                    _image = null;
+                }
                 if (_buffer != null)
                 {
                     _buffer.Dispose();
@@ -1769,12 +1774,16 @@ namespace Greenshot.Editor.Drawing
                 int verticalCorrection = targetClipRectangle.Top % (int) _zoomFactor.Numerator;
                 if (horizontalCorrection != 0)
                 {
-                    targetClipRectangle = targetClipRectangle.ChangeX(-horizontalCorrection).ChangeWidth(horizontalCorrection);
+                    targetClipRectangle = targetClipRectangle
+                        .ChangeX(targetClipRectangle.X - horizontalCorrection)
+                        .ChangeWidth(targetClipRectangle.Width + horizontalCorrection);
                 }
 
                 if (verticalCorrection != 0)
                 {
-                    targetClipRectangle = targetClipRectangle.ChangeY(-verticalCorrection).ChangeHeight(verticalCorrection);
+                    targetClipRectangle = targetClipRectangle
+                        .ChangeY(targetClipRectangle.Y - verticalCorrection)
+                        .ChangeHeight(targetClipRectangle.Height + verticalCorrection);
                 }
             }
 

--- a/src/Greenshot/Forms/CaptureForm.cs
+++ b/src/Greenshot/Forms/CaptureForm.cs
@@ -154,19 +154,22 @@ namespace Greenshot.Forms
 
             _currentForm = this;
 
-            // Enable the AnimatingForm
-            EnableAnimation = true;
-
             // clean up
             FormClosed += ClosedHandler;
             _capture = capture;
             _windows = windows;
             _captureMode = capture.CaptureDetails.CaptureMode;
 
-            //
+            // Set cursor location before enabling animations to avoid race condition
+            _cursorPos = WindowCapture.GetCursorLocationRelativeToScreenBounds();
+            _mouseMovePos = _cursorPos;
+
+            // Enable the AnimatingForm
+            EnableAnimation = true;
+
             // The InitializeComponent() call is required for Windows Forms designer support.
-            //
             InitializeComponent();
+
             // Only double-buffer when we are not in a TerminalServerSession
             DoubleBuffered = !IsTerminalServerSession;
             Text = @"Greenshot capture form";


### PR DESCRIPTION
This PR fixes for 1.3 the following which was already fixed in 1.4:

- #822 - Crash due to unexpected information on the clipboard
- #952 - CPU load due to background task scheduler bug
- #788 & #944 - Weird black areas in the editor when using 75% zoom

Additionally:

- Greenshot doesn't Windows 11 correctly and says Windows 10 in the error window
- Starting to draw an line/arrow starts with a wrong destination, this means it is briefly showing a line/arrow with an endpoint which wasn't picked yet.
- A glitch in the region capture, where the zoom/cross starts on the wrong position.
