### PR TITLE
[Fix] Prevent the possibility of disposing a shared font

### DIFF
--- a/src/Greenshot.Base/Core/AbstractDestination.cs
+++ b/src/Greenshot.Base/Core/AbstractDestination.cs
@@ -180,7 +180,8 @@ namespace Greenshot.Base.Core
             {
                 ImageScalingSize = CoreConfig.IconSize,
                 Tag = null,
-                TopLevel = true
+                TopLevel = true,
+                Font = new Font(FontFamily.GenericSansSerif, 9) // set new default font, so we are allowed to dispose it later, we will scale it later on the Opening event
             };
 
             menu.Opening += (sender, args) =>


### PR DESCRIPTION
In the opening event of the `PickeMenu`, we replace the existing font with a newly scaled one. 

We must only dispose the old font if we own its lifecycle. 
We have to ensure that the context menu uses a non-shared font instance to avoid side effects. 

In my case, the `ImageEditorForm` failed to open because the `FontFamilyComboBox` could not be initialized.