### PR TITLE
Adjust layout for check period controls

### DIFF
--- a/src/Greenshot/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot/Forms/SettingsForm.Designer.cs
@@ -502,20 +502,20 @@ namespace Greenshot.Forms {
 			// 
 			// numericUpDown_daysbetweencheck
 			// 
-			this.numericUpDown_daysbetweencheck.Location = new System.Drawing.Point(345, 37);
+			this.numericUpDown_daysbetweencheck.Location = new System.Drawing.Point(359, 37);
 			this.numericUpDown_daysbetweencheck.Name = "numericUpDown_daysbetweencheck";
-			this.numericUpDown_daysbetweencheck.Size = new System.Drawing.Size(57, 20);
+			this.numericUpDown_daysbetweencheck.Size = new System.Drawing.Size(44, 20);
 			this.numericUpDown_daysbetweencheck.TabIndex = 8;
 			this.numericUpDown_daysbetweencheck.ThousandsSeparator = true;
 			this.numericUpDown_daysbetweencheck.Minimum = 0;
 			this.numericUpDown_daysbetweencheck.Maximum = 365;
-			// 
+			//
 			// label_checkperiod
-			// 
+			//
 			this.label_checkperiod.LanguageKey = "settings_checkperiod";
 			this.label_checkperiod.Location = new System.Drawing.Point(5, 39);
 			this.label_checkperiod.Name = "label_checkperiod";
-			this.label_checkperiod.Size = new System.Drawing.Size(334, 23);
+			this.label_checkperiod.Size = new System.Drawing.Size(350, 23);
 			this.label_checkperiod.TabIndex = 19;
 			// 
 			// checkbox_usedefaultproxy


### PR DESCRIPTION
Tweaks layout in SettingsForm.Designer.cs for the check period UI: moves numericUpDown_daysbetweencheck from (345,37) to (359,37) and reduces its width from 57 to 44, and increases label_checkperiod width from 334 to 350 to improve alignment. Also normalizes some comment spacing in the designer file.

Fixes - https://github.com/greenshot/greenshot/issues/934