### PR TITLE
Handle IO exceptions when saving image

### DIFF
--- a/src/Greenshot.Base/Core/ImageIO.cs
+++ b/src/Greenshot.Base/Core/ImageIO.cs
@@ -380,7 +380,7 @@ namespace Greenshot.Base.Core
                     returnValue = fileNameWithExtension;
                     IniConfig.Save();
                 }
-                catch (ExternalException)
+                catch (Exception e) when (e is ExternalException || e is IOException)
                 {
                     MessageBox.Show(Language.GetFormattedString("error_nowriteaccess", saveImageFileDialog.FileName).Replace(@"\\", @"\"), Language.GetString("error"));
                 }


### PR DESCRIPTION
Root cause: System.IO.IOException is thrown when the file is locked by another process. It is not a subclass of ExternalException (which is COM/interop-related), so the original catch (ExternalException) block never fired, and the exception propagated all the way up, causing the crash report.

Fix: Changed to a when filter pattern — catch (Exception e) when (e is ExternalException || e is IOException) — so both cases are caught and the user sees the existing "Cannot save file to {0}" error dialogue instead of a crash.

Behaviour after the fix: The user gets the error dialogue, dismisses it, and SaveWithDialog returns null. The caller (FileWithDialogDestination.cs:60) already checks for null and skips updating the path — so the user can simply invoke Save As again and choose a different filename.

Fixes https://github.com/greenshot/greenshot/issues/946