### PR TITLE
Update AbstractAdorner.cs to fix issues/925

### DIFF
--- a/src/Greenshot.Editor/Drawing/Adorners/AbstractAdorner.cs
+++ b/src/Greenshot.Editor/Drawing/Adorners/AbstractAdorner.cs
@@ -154,13 +154,13 @@ namespace Greenshot.Editor.Drawing.Adorners
         {
             Graphics targetGraphics = paintEventArgs.Graphics;
 
-            var bounds = BoundsOnSurface;
             GraphicsState state = targetGraphics.Save();
 
             targetGraphics.CompositingMode = CompositingMode.SourceCopy;
 
             try
             {
+                var bounds = BoundsOnSurface;
                 using var fillBrush = new SolidBrush(FillColor);
                 targetGraphics.FillRectangle(fillBrush, bounds);
                 using var lineBrush = new SolidBrush(OutlineColor);


### PR DESCRIPTION
I couldnt replicate either but found why this caused the crash - Moving var bounds = BoundsOnSurface; inside the existing try/catch block in AbstractAdorner.Paint fixes a NullReferenceException that crashed the editor whenever the user released the mouse after drawing a crop selection. The property BoundsOnSurface calls Owner.Parent.ToSurfaceCoordinates(...), but Parent is set to null by RemoveElement during crop teardown before the pending WM_PAINT message is processed — meaning a repaint could fire against a container that was already mid-disposal. That call was sitting above the try/catch that already existed to suppress paint-time errors (noted as BUG-2065), so it was completely unprotected. Moving it one line down into the same try block means any NullReferenceException from a partially-torn-down adorner is silently swallowed during that paint cycle — the adorner simply draws nothing, which is the correct behaviour since the container is already being removed anyway.

Fixes https://github.com/greenshot/greenshot/issues/925