### PR TITLE
Fix crash when changing icon size in preferences /issues/1007

### DIFF
--- a/src/Greenshot.Base/Core/CoreConfiguration.cs
+++ b/src/Greenshot.Base/Core/CoreConfiguration.cs
@@ -343,7 +343,7 @@ namespace Greenshot.Base.Core
                     {
                         newSize.Height = 16;
                     }
-                    else if (IconSize.Height > 256)
+                    else if (newSize.Height > 256)
                     {
                         newSize.Height = 256;
                     }
@@ -353,7 +353,7 @@ namespace Greenshot.Base.Core
 
                 if (_iconSize != newSize)
                 {
-                    _iconSize = value;
+                    _iconSize = newSize;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IconSize"));
                 }
             }

--- a/src/Greenshot/Forms/ToolStripMenuSelectList.cs
+++ b/src/Greenshot/Forms/ToolStripMenuSelectList.cs
@@ -39,7 +39,7 @@ namespace Greenshot.Forms
         private readonly bool _multiCheckAllowed;
         private readonly IProvideDeviceDpi _provideDeviceDpi;
         private bool _updateInProgress;
-        private static Image _defaultImage;
+        private Image _defaultImage;
 
         /// <summary>
         /// Occurs when one of the list's child element's Checked state changes.
@@ -138,6 +138,16 @@ namespace Greenshot.Forms
         public void AddItem(string label, object data, bool isChecked)
         {
             AddItem(label, null, data, isChecked);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _defaultImage?.Dispose();
+                _defaultImage = null;
+            }
+            base.Dispose(disposing);
         }
 
         /// <summary>


### PR DESCRIPTION
Changing the icon size in Preferences was causing the app to crash the next time you clicked the tray icon. This happened because the placeholder images used in the quick-settings menu were stored in a single shared variable — so when the settings were rebuilt with the new icon size, that shared image got destroyed, but the old menu items were still pointing at it. When Windows tried to paint them, it hit a dead image and threw an exception. The fix gives each menu instance its own image so they can't step on each other, and also corrects a typo that was causing the wrong (unvalidated) icon size value to actually get saved.

Fixes https://github.com/greenshot/greenshot/issues/1007