### PR TITLE
[Fix] Use action SaveToStream as filter in TrySaveToStream()

### DIFF
--- a/src/Greenshot.Base/Core/FileFormatHandlers/FileFormatHandlerExtensions.cs
+++ b/src/Greenshot.Base/Core/FileFormatHandlers/FileFormatHandlerExtensions.cs
@@ -90,8 +90,8 @@ namespace Greenshot.Base.Core.FileFormatHandlers
             extension = NormalizeExtension(extension);
 
             var saveFileFormatHandlers = fileFormatHandlers
-                .Where(ffh => ffh.Supports(FileFormatHandlerActions.LoadFromStream, extension))
-                .OrderBy(ffh => ffh.PriorityFor(FileFormatHandlerActions.LoadFromStream, extension)).ToList();
+                .Where(ffh => ffh.Supports(FileFormatHandlerActions.SaveToStream, extension))
+                .OrderBy(ffh => ffh.PriorityFor(FileFormatHandlerActions.SaveToStream, extension)).ToList();
 
             if (!saveFileFormatHandlers.Any())
             {


### PR DESCRIPTION
I've stumbled across this so many times. Now I turn it into a PR.

This change has no effect on many FileFormatHandlers because `LoadFromStream` and `SaveToStream` mostly contain the same file extensions.