### PR TITLE
Add safety checks, locking, and sync fixes

### DIFF
--- a/src/Greenshot.Base/Core/Fraction.cs
+++ b/src/Greenshot.Base/Core/Fraction.cs
@@ -82,7 +82,7 @@ namespace Greenshot.Base.Core
         }
 
         public int CompareTo(Fraction other)
-            => (int) (Numerator * other.Denominator) - (int) (other.Numerator * Denominator);
+            => ((long) Numerator * other.Denominator).CompareTo((long) other.Numerator * Denominator);
 
         #endregion
 

--- a/src/Greenshot.Base/Core/ImageHelper.cs
+++ b/src/Greenshot.Base/Core/ImageHelper.cs
@@ -74,6 +74,10 @@ namespace Greenshot.Base.Core
                 }
 
                 PropertyItem item = image.GetPropertyItem(ExifOrientationId);
+                if (item.Value == null || item.Value.Length == 0)
+                {
+                    return;
+                }
 
                 ExifOrientations orientation = (ExifOrientations) item.Value[0];
                 // Orient the image.
@@ -1249,7 +1253,12 @@ namespace Greenshot.Base.Core
             else
             {
                 // Let GDI+ decide how to convert, need to test what is quicker...
-                newImage = (sourceImage as Bitmap).Clone(sourceRect, targetFormat);
+                var sourceBitmap = sourceImage as Bitmap;
+                if (sourceBitmap == null)
+                {
+                    throw new InvalidOperationException($"Expected Bitmap but got {sourceImage?.GetType().Name}");
+                }
+                newImage = sourceBitmap.Clone(sourceRect, targetFormat);
                 // Make sure both images have the same resolution
                 newImage.SetResolution(sourceImage.HorizontalResolution, sourceImage.VerticalResolution);
             }

--- a/src/Greenshot.Base/Core/NetworkHelper.cs
+++ b/src/Greenshot.Base/Core/NetworkHelper.cs
@@ -116,6 +116,7 @@ namespace Greenshot.Base.Core
                 catch (Exception)
                 {
                     // If we arrive here, the image loading didn't work, try to see if the response has a http(s) URL to an image and just take this instead.
+                    memoryStream.Seek(0, SeekOrigin.Begin);
                     string content;
                     using (var streamReader = new StreamReader(memoryStream, Encoding.UTF8, true))
                     {
@@ -177,6 +178,7 @@ namespace Greenshot.Base.Core
                 catch (Exception)
                 {
                     // If we arrive here, the image loading didn't work, try to see if the response has a http(s) URL to an image and just take this instead.
+                    memoryStream.Seek(0, SeekOrigin.Begin);
                     string content;
                     using (var streamReader = new StreamReader(memoryStream, Encoding.UTF8, true))
                     {

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -71,6 +71,7 @@ namespace Greenshot.Editor.Forms
         };
 
         private static readonly List<IImageEditor> EditorList = new();
+        private static readonly object _editorListLock = new();
 
         private Surface _surface;
         private GreenshotToolStripButton[] _toolbarButtons;
@@ -101,16 +102,19 @@ namespace Greenshot.Editor.Forms
         {
             get
             {
-                try
+                lock (_editorListLock)
                 {
-                    EditorList.Sort((e1, e2) => string.Compare(e1.Surface.CaptureDetails.Title, e2.Surface.CaptureDetails.Title, StringComparison.Ordinal));
-                }
-                catch (Exception ex)
-                {
-                    Log.Warn("Sorting of editors failed.", ex);
-                }
+                    try
+                    {
+                        EditorList.Sort((e1, e2) => string.Compare(e1.Surface.CaptureDetails.Title, e2.Surface.CaptureDetails.Title, StringComparison.Ordinal));
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warn("Sorting of editors failed.", ex);
+                    }
 
-                return EditorList;
+                    return EditorList;
+                }
             }
         }
 
@@ -148,7 +152,10 @@ namespace Greenshot.Editor.Forms
             // Compute emojis in background
             EmojiData.Load();
 
-            EditorList.Add(this);
+            lock (_editorListLock)
+            {
+                EditorList.Add(this);
+            }
 
             //
             // The InitializeComponent() call is required for Windows Forms designer support.
@@ -1015,7 +1022,10 @@ namespace Greenshot.Editor.Forms
             IniConfig.Save();
 
             // remove from the editor list
-            EditorList.Remove(this);
+            lock (_editorListLock)
+            {
+                EditorList.Remove(this);
+            }
 
             _surface.Dispose();
 

--- a/src/Greenshot.Editor/Helpers/ScaleHelper.cs
+++ b/src/Greenshot.Editor/Helpers/ScaleHelper.cs
@@ -243,8 +243,8 @@ namespace Greenshot.Editor.Helpers
 
             if (centeredScale)
             {
-                float wdiff = result.Width - result.Width;
-                float hdiff = result.Height - result.Height;
+                float wdiff = (result.Width - boundsBeforeResize.Width) / 2;
+                float hdiff = (result.Height - boundsBeforeResize.Height) / 2;
                 result = result.Inflate(wdiff, hdiff);
             }
 

--- a/src/Greenshot.Plugin.Confluence/Confluence.cs
+++ b/src/Greenshot.Plugin.Confluence/Confluence.cs
@@ -96,8 +96,7 @@ public class ConfluenceConnector : IDisposable
             _confluence.SetBasicAuthentication(user, password);
             
             // Test the credentials by getting current user info
-            var testTask = Task.Run(async () => await _confluence.User.GetCurrentUserAsync().ConfigureAwait(false));
-            testTask.Wait();
+            Task.Run(async () => await _confluence.User.GetCurrentUserAsync().ConfigureAwait(false)).GetAwaiter().GetResult();
             
             _loggedInTime = DateTime.Now;
             _loggedIn = true;
@@ -200,13 +199,11 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var attachTask = Task.Run(async () =>
+        Task.Run(async () =>
         {
             using var stream = new System.IO.MemoryStream(image.ToByteArray());
             await _confluence.Attachment.AttachAsync(pageId, stream, filename, comment, mime).ConfigureAwait(false);
-        });
-        
-        attachTask.Wait();
+        }).GetAwaiter().GetResult();
     }
 
     public Entities.Page GetPage(string spaceKey, string pageTitle)
@@ -222,7 +219,7 @@ public class ConfluenceConnector : IDisposable
         {
             CheckCredentials();
             
-            var pageTask = Task.Run(async () =>
+            page = Task.Run(async () =>
             {
                 var query = Where.And(Where.Type.IsPage, Where.Title.Is(pageTitle), Where.Space.Is(spaceKey));
                 var searchResult = await _confluence.Content.SearchAsync(query, pagingInformation: new PagingInformation
@@ -230,16 +227,13 @@ public class ConfluenceConnector : IDisposable
                     Limit = 1
                 }).ConfigureAwait(false);
                 return searchResult.Results.FirstOrDefault();
-            });
-            
-            page = pageTask.Result;
-            
+            }).GetAwaiter().GetResult();
+
             if (page != null)
             {
                 // Get full page details with body
-                var detailTask = Task.Run(async () => 
-                    await _confluence.Content.GetAsync(page, ConfluenceClientConfig.ExpandGetContentWithStorage).ConfigureAwait(false));
-                page = detailTask.Result;
+                page = Task.Run(async () =>
+                    await _confluence.Content.GetAsync(page, ConfluenceClientConfig.ExpandGetContentWithStorage).ConfigureAwait(false)).GetAwaiter().GetResult();
                 _pageCache.Add(cacheKey, page);
             }
         }
@@ -261,10 +255,8 @@ public class ConfluenceConnector : IDisposable
         {
             CheckCredentials();
             
-            var pageTask = Task.Run(async () =>
-                await _confluence.Content.GetAsync(pageId, ConfluenceClientConfig.ExpandGetContentWithStorage).ConfigureAwait(false));
-                
-            page = pageTask.Result;
+            page = Task.Run(async () =>
+                await _confluence.Content.GetAsync(pageId, ConfluenceClientConfig.ExpandGetContentWithStorage).ConfigureAwait(false)).GetAwaiter().GetResult();
             _pageCache.Add(cacheKey, page);
         }
 
@@ -275,7 +267,7 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var homePageTask = Task.Run(async () =>
+        var page = Task.Run(async () =>
         {
             var space = await _confluence.Space.GetAsync(spaceSummary.Key).ConfigureAwait(false);
             if (space.HomepageId != 0)
@@ -283,9 +275,7 @@ public class ConfluenceConnector : IDisposable
                 return await _confluence.Content.GetAsync(space.HomepageId, ConfluenceClientConfig.ExpandGetContentWithStorage).ConfigureAwait(false);
             }
             return null;
-        });
-        
-        var page = homePageTask.Result;
+        }).GetAwaiter().GetResult();
         return page != null ? new Entities.Page(page) : null;
     }
 
@@ -293,20 +283,18 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var spacesTask = Task.Run(async () =>
+        var spaces = Task.Run(async () =>
         {
             var allSpaces = new List<Dapplo.Confluence.Entities.Space>();
             var spacesResult = await _confluence.Space.GetAllAsync().ConfigureAwait(false);
-            
+
             foreach (var space in spacesResult)
             {
                 allSpaces.Add(space);
             }
-            
+
             return allSpaces;
-        });
-        
-        var spaces = spacesTask.Result;
+        }).GetAwaiter().GetResult();
         
         foreach (var space in spaces)
         {
@@ -318,20 +306,18 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var childrenTask = Task.Run(async () =>
+        var pages = Task.Run(async () =>
         {
             var children = new List<Content>();
             var childrenResult = await _confluence.Content.GetChildrenAsync(parentPage.Id).ConfigureAwait(false);
-            
+
             if (childrenResult?.Results != null)
             {
                 children.AddRange(childrenResult.Results);
             }
-            
+
             return children;
-        });
-        
-        var pages = childrenTask.Result;
+        }).GetAwaiter().GetResult();
         
         foreach (var page in pages)
         {
@@ -343,21 +329,19 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var pagesTask = Task.Run(async () =>
+        var pages = Task.Run(async () =>
         {
             var allPages = new List<Content>();
             var query = Where.And(Where.Type.IsPage, Where.Space.Is(space.Key));
             var searchResult = await _confluence.Content.SearchAsync(query).ConfigureAwait(false);
-            
+
             foreach (var page in searchResult.Results)
             {
                 allPages.Add(page);
             }
-            
+
             return allPages;
-        });
-        
-        var pages = pagesTask.Result;
+        }).GetAwaiter().GetResult();
         
         foreach (var page in pages)
         {
@@ -369,11 +353,11 @@ public class ConfluenceConnector : IDisposable
     {
         CheckCredentials();
         
-        var searchTask = Task.Run(async () =>
+        var pages = Task.Run(async () =>
         {
             var allPages = new List<Content>();
             IFinalClause whereClause;
-            
+
             if (!string.IsNullOrEmpty(space))
             {
                 whereClause = Where.And(Where.Type.IsPage, Where.Text.Contains(query), Where.Space.Is(space));
@@ -382,9 +366,9 @@ public class ConfluenceConnector : IDisposable
             {
                 whereClause = Where.And(Where.Type.IsPage, Where.Text.Contains(query));
             }
-            
+
             var searchResult = await _confluence.Content.SearchAsync(whereClause, pagingInformation: new PagingInformation { Limit = 20 }).ConfigureAwait(false);
-            
+
             foreach (var page in searchResult.Results)
             {
                 Log.DebugFormat("Got result of type {0}", page.Type);
@@ -393,11 +377,9 @@ public class ConfluenceConnector : IDisposable
                     allPages.Add(page);
                 }
             }
-            
+
             return allPages;
-        });
-        
-        var pages = searchTask.Result;
+        }).GetAwaiter().GetResult();
         
         foreach (var page in pages)
         {

--- a/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
@@ -86,9 +86,14 @@ namespace Greenshot.Plugin.Office.OfficeExport
             {
                 wordApplication = OleAut32Api.GetActiveObject<Application>("Word.Application");
             }
-            catch (Exception)
+            catch (System.Runtime.InteropServices.COMException)
             {
-                // Ignore, probably no word running
+                // Word is not running, this is expected
+                return null;
+            }
+            catch (Exception ex)
+            {
+                LOG.Warn("Unexpected error while getting Word application instance.", ex);
                 return null;
             }
 

--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -803,13 +803,18 @@ namespace Greenshot.Forms
             }
 
             var oneDriveSettingsFile = Directory.GetFiles(oneDriveSettingsPath, "*_screenshot.dat").FirstOrDefault();
-            if (!File.Exists(oneDriveSettingsFile))
+            if (oneDriveSettingsFile == null || !File.Exists(oneDriveSettingsFile))
             {
                 return false;
             }
 
-            var screenshotSetting = File.ReadAllLines(oneDriveSettingsFile).Skip(1).Take(1).First();
-            return "2".Equals(screenshotSetting);
+            var lines = File.ReadAllLines(oneDriveSettingsFile);
+            if (lines.Length < 2)
+            {
+                return false;
+            }
+
+            return "2".Equals(lines[1]);
         }
 
         /// <summary>


### PR DESCRIPTION
These fixes have been sitting in my notes for a while — a mixture of things spotted during general code sessions, digging through edge cases while working on other fixes, and a few that came up from just reading through areas of the codebase I don't normally touch day to day.

The ScaleHelper one in particular had been nagging at me for some time, knowing the centred scale behaviour felt off but not getting around to properly tracing through the geometry until now. Figured it was time to get them all tidied up and submitted rather than letting them sit any longer.

Full breakdown below, none of these fix actual reported issue, but do improve the code quality somewhat. A full review on this please if possible to ensure all is ship shape 👌🤞

**MainForm.cs — OneDrive settings null guard**
Added explicit null check on FirstOrDefault() before passing to File.Exists(), and replaced the .Skip(1).Take(1).First() chain with a bounds-checked array index.

**ImageHelper.cs — Unsafe as cast dereference**
Null-checked the as Bitmap result before calling .Clone() so a non-Bitmap image type throws a meaningful exception instead of a silent NullReferenceException.

**ImageHelper.cs — EXIF bounds check**
Added a Value == null || Value.Length == 0 guard before indexing EXIF orientation data to prevent IndexOutOfRangeException on malformed images.

**Confluence.cs — Async deadlock risk**
Replaced all .Wait() and .Result blocking calls (7 occurrences) with .GetAwaiter().GetResult() to eliminate SynchronizationContext deadlock potential on the WinForms UI thread.

**NetworkHelper.cs** — Stream position not reset on retry. Added memoryStream.Seek(0, SeekOrigin.Begin) before the fallback re-read in both catch blocks so the stream isn't read from mid-position after a failed image load attempt.

**WordExporter.cs — Blanket exception swallowing**
Split the catch-all catch (Exception) into a targeted catch (COMException) for the expected "Word not running" case, with an explicit LOG. Warn catch for anything unexpected.

**Fraction.cs — Integer overflow in CompareTo**
Cross-multiplied comparison now casts to long before multiplying to prevent silent uint overflow wrapping that would invert sort order for large fraction values.

**ImageEditorForm.cs — Unsynchronised static list**
Added a _editorListLock object and wrapped all three EditorList accesses (Add, Remove, Sort) in lock blocks to prevent list corruption when multiple editor windows open or close concurrently.

**ScaleHelper.cs** — Centred scale completely non-functional. This was a really interesting one to work on — the centred scale block was computing result.Width - result.Width and result.Height - result.Height, both of which are always zero, meaning Inflate was always called with no-op deltas and Ctrl+resize centring had silently never worked. The fix computes the diff between the scaled result and the original boundsBeforeResize, divides by 2, and passes that to Inflate — which grows each edge outward symmetrically, giving you the correct anchor-at-centre behaviour.