### PR TITLE
Update ImageIO.cs to fix reported issues

### DIFF
--- a/src/Greenshot.Base/Core/ImageIO.cs
+++ b/src/Greenshot.Base/Core/ImageIO.cs
@@ -430,7 +430,7 @@ namespace Greenshot.Base.Core
                     returnValue = fileNameWithExtension;
                     IniConfig.Save();
                 }
-                catch (Exception e) when (e is ExternalException || e is IOException)
+                catch (Exception e) when (e is ExternalException || e is IOException || e is UnauthorizedAccessException)
                 {
                     MessageBox.Show(Language.GetFormattedString("error_nowriteaccess", saveImageFileDialog.FileName).Replace(@"\\", @"\"), Language.GetString("error"));
                 }


### PR DESCRIPTION
Both reported errors occur at the same point in the call stack — ImageIO.SaveWithDialog — where the FileStream constructor throws when it cannot open the file for writing. The existing catch filter only handled ExternalException and IOException, but UnauthorizedAccessException (thrown when the OS denies access due to file permissions or a read-only attribute) is a sibling class in the hierarchy, not a subclass of IOException, so it fell through unhandled and crashed as an unhandled exception. The file-locked IOException was technically caught, but the fix consolidates both under the same user-friendly "cannot save" message. Adding UnauthorizedAccessException to the catch filter means both scenarios — permission denied and file in use — are now caught in the same place and shown to the user as a clear, localised error message rather than an unhandled exception dialog.

Fixes https://github.com/greenshot/greenshot/issues/807 and https://github.com/greenshot/greenshot/issues/1038