### PR TITLE
Update PluginUtils.cs to fix icons

### DIFF
--- a/src/Greenshot.Base/Core/PluginUtils.cs
+++ b/src/Greenshot.Base/Core/PluginUtils.cs
@@ -170,6 +170,21 @@ namespace Greenshot.Base.Core
                 Log.Error("error retrieving icon: ", exIcon);
             }
 
+            // Fallback: use the Windows shell-associated icon (handles exes with no embedded icon, e.g. Windows curl.exe)
+            try
+            {
+                var shellIcon = Icon.ExtractAssociatedIcon(path);
+                if (shellIcon != null)
+                {
+                    Log.DebugFormat("Loaded shell icon for {0}", path);
+                    return shellIcon.ToBitmap();
+                }
+            }
+            catch (Exception exShell)
+            {
+                Log.Warn("error retrieving shell icon: ", exShell);
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes an issue where External Command plugin entries using executables with no embedded icon resource (such as the Windows built-in curl.exe, tar.exe, and ssh.exe) were silently excluded from the editor toolbar. The toolbar's AddDestinations() method skips any destination whose DisplayIcon is null, and PluginUtils.GetExeIcon() was only using Dapplo.Windows.Icons.IconHelper.ExtractAssociatedIcon, which returns null for executables with no embedded icon. A fallback to Icon.ExtractAssociatedIcon() has been added, which goes through the Windows shell and always returns an icon (typically the generic console application icon for iconless executables).

<img width="130" height="84" alt="image" src="https://github.com/user-attachments/assets/a6dc9485-9f33-4cd9-9c32-4a692e1d86a1" />

Executables that already have an embedded icon are unaffected — the fallback is only reached when IconHelper returns null. The affected entries were still visible in the context menu since that code path has no null icon guard, making the omission from the toolbar inconsistent and confusing.

Tested with various random icons

<img width="239" height="257" alt="image" src="https://github.com/user-attachments/assets/d260fc0e-536e-459f-8d7a-6f5d21e0a825" />

<img width="476" height="113" alt="image" src="https://github.com/user-attachments/assets/d52c2600-cfe8-4e88-8b1c-39ae0530bfdb" />


Fixes https://github.com/greenshot/greenshot/issues/1036