### PR TITLE
Handle COM version parse failures in exporters

### DIFF
--- a/src/Greenshot.Plugin.Office/OfficeExport/ExcelExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/ExcelExporter.cs
@@ -112,9 +112,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 return;
             }
 
-            if (!Version.TryParse(excelApplication.ComObject.Version, out _excelVersion))
+            try
             {
-                LOG.Warn("Assuming Excel version 1997.");
+                if (!Version.TryParse(excelApplication.ComObject.Version, out _excelVersion))
+                {
+                    LOG.Warn("Could not determine Excel version, assuming minimum.");
+                    _excelVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                }
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Failed to get Excel version via COM (possible type library mismatch), assuming minimum.", ex);
                 _excelVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
             }
         }

--- a/src/Greenshot.Plugin.Office/OfficeExport/OutlookEmailExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/OutlookEmailExporter.cs
@@ -681,9 +681,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 return;
             }
 
-            if (!Version.TryParse(outlookApplication.ComObject.Version, out _outlookVersion))
+            try
             {
-                LOG.Warn("Assuming outlook version 1997.");
+                if (!Version.TryParse(outlookApplication.ComObject.Version, out _outlookVersion))
+                {
+                    LOG.Warn("Could not determine Outlook version, assuming minimum.");
+                    _outlookVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                }
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Failed to get Outlook version via COM (possible type library mismatch), assuming minimum.", ex);
                 _outlookVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
             }
 

--- a/src/Greenshot.Plugin.Office/OfficeExport/PowerpointExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/PowerpointExporter.cs
@@ -315,9 +315,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 return;
             }
 
-            if (!Version.TryParse(powerpointApplication.ComObject.Version, out _powerpointVersion))
+            try
             {
-                LOG.Warn("Assuming Powerpoint version 1997.");
+                if (!Version.TryParse(powerpointApplication.ComObject.Version, out _powerpointVersion))
+                {
+                    LOG.Warn("Could not determine PowerPoint version, assuming minimum.");
+                    _powerpointVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                }
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Failed to get PowerPoint version via COM (possible type library mismatch), assuming minimum.", ex);
                 _powerpointVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
             }
         }

--- a/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
@@ -159,16 +159,16 @@ namespace Greenshot.Plugin.Office.OfficeExport
             }
             catch (InvalidCastException ex)
             {
-                LOG.Warn("Unable to retrieve Word version due to COM interface casting issue. Assuming Word version 1997.", ex);
+                LOG.Warn("Failed to get Word version via COM (possible type library mismatch), assuming minimum.", ex);
             }
             catch (Exception ex)
             {
-                LOG.Warn("Unable to retrieve Word version. Assuming Word version 1997.", ex);
+                LOG.Warn("Could not determine Word version, assuming minimum.", ex);
             }
 
             if (_wordVersion == null)
             {
-                LOG.Warn("Assuming Word version 1997.");
+                LOG.Warn("Could not determine Word version, assuming minimum.");
                 _wordVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
             }
         }


### PR DESCRIPTION
Extends the InvalidCastException COM type library mismatch fix — already present in WordExporter — to ExcelExporter, OutlookEmailExporter, and PowerpointExporter. This prevents an unhandled exception when exporting to Office applications on Microsoft 365 (Click-to-Run) installatins, where querying the Office version via COM fails due to a stale or mismatched type library registration. When the version cannot be determined, the code falls back to the minimum known version (Office97/8.0), which causes all version-gated feature checks to evaluate conservatively — the safest possible behaviour

Fixes https://github.com/greenshot/greenshot/issues/916