### PR TITLE
Handle InitializeVariables failure, default to Office97

### DIFF
--- a/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
@@ -71,7 +71,16 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 wordApplication = DisposableCom.Create(new Application());
             }
 
-            InitializeVariables(wordApplication);
+            try
+            {
+                InitializeVariables(wordApplication);
+            }
+            catch (Exception ex)
+            {
+                LOG.Warn("Unable to initialize Word variables, assuming Word version 1997.", ex);
+                _wordVersion ??= new Version((int) OfficeVersions.Office97, 0, 0, 0);
+            }
+
             return wordApplication;
         }
 
@@ -99,7 +108,15 @@ namespace Greenshot.Plugin.Office.OfficeExport
 
             if ((wordApplication != null) && (wordApplication.ComObject != null))
             {
-                InitializeVariables(wordApplication);
+                try
+                {
+                    InitializeVariables(wordApplication);
+                }
+                catch (Exception ex)
+                {
+                    LOG.Warn("Unable to initialize Word variables, assuming Word version 1997.", ex);
+                    _wordVersion ??= new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                }
             }
 
             return wordApplication;


### PR DESCRIPTION
Wrap InitializeVariables calls in try/catch to prevent an unhandled InvalidCastException when Word's COM type library is in a degraded state (TYPE_E_ELEMENTNOTFOUND), falling back to Word 97 compatibility instead of crashing the capture.

Saw this as an issue off the back of the last one re Excel...

Fixes https://github.com/greenshot/greenshot/issues/910