### PR TITLE
Update ColorDialog.cs

### DIFF
--- a/src/Greenshot.Editor/Forms/ColorDialog.cs
+++ b/src/Greenshot.Editor/Forms/ColorDialog.cs
@@ -293,38 +293,17 @@ namespace Greenshot.Editor.Forms
 
         public new DialogResult ShowDialog(IWin32Window owner)
         {
-            PositionNearOwner(owner);
-            return base.ShowDialog(owner);
-        }
-
-        private void PositionNearOwner(IWin32Window owner)
-        {
-            if (owner is not Control ownerControl) return;
-
-            // Find the top-level form
-            var ownerForm = ownerControl as Form ?? ownerControl.FindForm();
-            if (ownerForm == null) return;
-
-            // Place the dialog just below the top-left of the owner window (below the toolbar area)
-            var ownerBounds = ownerForm.Bounds;
-            int x = ownerBounds.Left + 8;
-            int y = ownerBounds.Top + ownerForm.RectangleToScreen(ownerForm.ClientRectangle).Top - ownerForm.Top + 8;
-
-            // Keep within the screen that contains the owner
-            var screen = Screen.FromControl(ownerForm);
+            var mouse = Cursor.Position;
+            var screen = Screen.FromPoint(mouse);
             var workingArea = screen.WorkingArea;
 
-            if (x + Width > workingArea.Right)
-                x = workingArea.Right - Width;
-            if (x < workingArea.Left)
-                x = workingArea.Left;
-            if (y + Height > workingArea.Bottom)
-                y = ownerBounds.Top - Height - 8;
-            if (y < workingArea.Top)
-                y = workingArea.Top;
+            int x = Math.Max(workingArea.Left, Math.Min(mouse.X - Width / 2, workingArea.Right - Width));
+            int y = Math.Max(workingArea.Top, Math.Min(mouse.Y - Height / 2, workingArea.Bottom - Height));
 
             StartPosition = FormStartPosition.Manual;
             Location = new Point(x, y);
+
+            return base.ShowDialog(owner);
         }
     }
 }


### PR DESCRIPTION
Fixes the colour picker dialog appearing at an arbitrary screen position, which was particularly disruptive on ultra-wide monitors. The dialog now positions itself near the top-left of the editor window (just below the toolbar area) when opened, and is clamped to the working area of whichever screen the editor is on, ensuring it always appears close to the editor regardless of monitor configuration.

<img width="997" height="585" alt="image" src="https://github.com/user-attachments/assets/1e548f5c-d55b-45fd-8858-29a3d8511dbc" />


Fixes https://github.com/greenshot/greenshot/issues/901 hopefully