### PR TITLE
Fixing my mistakes

### DIFF
--- a/src/Greenshot.Editor/Configuration/LanguageKeys.cs
+++ b/src/Greenshot.Editor/Configuration/LanguageKeys.cs
@@ -61,6 +61,7 @@ namespace Greenshot.Editor.Configuration
         settings_destination,
         settings_destination_clipboard,
         settings_destination_editor,
+        settings_destination_editor_add,
         settings_destination_fileas,
         settings_destination_printer,
         settings_destination_picker,

--- a/src/Greenshot.Editor/Destinations/EditorDestination.cs
+++ b/src/Greenshot.Editor/Destinations/EditorDestination.cs
@@ -65,8 +65,8 @@ namespace Greenshot.Editor.Destinations
                 }
 
                 var title = editor.CaptureDetails?.Title;
-                if (title == null) return Language.GetString(LangKey.settings_destination_editor);
-                return Language.GetString(LangKey.settings_destination_editor) + " - " + title.Substring(0, Math.Min(20, title.Length));
+                if (title == null) return Language.GetString(LangKey.settings_destination_editor_add);
+                return Language.GetString(LangKey.settings_destination_editor_add) + " - " + title.Substring(0, Math.Min(20, title.Length));
             }
         }
 

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -187,14 +187,18 @@ namespace Greenshot.Editor.Forms
             // Initial "saved" flag for asking if the image needs to be save
             _surface.Modified = !outputMade;
 
-            // Only register in the global editor list after the surface is fully assigned,
-            // so background threads iterating Editors never see a partially-initialized editor.
-            lock (_editorListLock)
-            {
-                EditorList.Add(this);
-            }
+            // Note: SetSurface (called via Surface = surface above) already registered this
+            // editor in EditorList. Do NOT add again here — double-registration causes
+            // closed editors to linger in the list because Remove() only removes one entry.
 
             UpdateUi();
+
+            // Re-apply the capture title after UpdateUi()/ApplyLanguage() which resets Text
+            // to just the bare form language key ("Greenshot editor").
+            if (_surface?.CaptureDetails?.Title != null)
+            {
+                Text = _surface.CaptureDetails.Title + " - " + Language.GetString(LangKey.editor_title);
+            }
 
             // Workaround: for the MouseWheel event which doesn't get to the panel
             MouseWheel += PanelMouseWheel;

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -238,6 +238,7 @@ Please check write accessibility of the selected storage location.</resource>
 		<resource name="settings_destination">Destination</resource>
 		<resource name="settings_destination_clipboard">Copy to clipboard</resource>
 		<resource name="settings_destination_editor">Open in image editor</resource>
+		<resource name="settings_destination_editor_add">Add to editor</resource>
 		<resource name="settings_destination_email">E-Mail</resource>
 		<resource name="settings_destination_file">Save directly (using settings below)</resource>
 		<resource name="settings_destination_fileas">Save as (displaying dialog)</resource>


### PR DESCRIPTION
This fix addresses two bugs introduced with #1051 (not #1027 that I also suspected) that affected the image editor.

The first was a double-registration issue in ImageEditorForm.Initialize() — when a new editor opened, it was being added to the global EditorList twice (once by SetSurface() and again explicitly in Initialize()). Since List.Remove() only removes the first occurrence; closing an editor left a ghost entry behind, causing the "Open in image editor" destination picker submenu to accumulate stale closed-editor entries indefinitely.

The second bug was that UpdateUi() → ApplyLanguage() was overwriting the editor window title (set correctly by SetSurface()) with just the bare "Greenshot editor" string on every new editor open — this has been fixed by re-applying the capture title after UpdateUi() completes.

Additionally, the submenu entries targeting a specific open editor have been renamed from "Open in image editor" to "Add to editor....." for clarity, since selecting one of those entries adds the new screenshot as an image object into an already-open editor rather than opening a fresh one.

Apologies for the disruption — both root causes are now properly resolved! 🙈

Fixes https://github.com/greenshot/greenshot/issues/1060