### PR TITLE
Fix Dapplo version mixing

### DIFF
--- a/src/Greenshot.Base/Greenshot.Base.csproj
+++ b/src/Greenshot.Base/Greenshot.Base.csproj
@@ -12,12 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Dapplo.HttpExtensions.JsonNet" Version="2.0.12" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="Dapplo.Windows.Clipboard" Version="2.0.63" />
-    <PackageReference Include="Dapplo.Windows.Dpi" Version="2.0.63" />
-    <PackageReference Include="Dapplo.Windows.Gdi32" Version="2.0.63" />
-    <PackageReference Include="Dapplo.Windows.Icons" Version="2.0.63" />
-    <PackageReference Include="Dapplo.Windows.Kernel32" Version="2.0.63" />
-    <PackageReference Include="Dapplo.Windows.Multimedia" Version="2.0.63" />
+    <PackageReference Include="Dapplo.Windows.Clipboard" Version="2.0.83" />
+    <PackageReference Include="Dapplo.Windows.Dpi" Version="2.0.83" />
+    <PackageReference Include="Dapplo.Windows.Gdi32" Version="2.0.83" />
+    <PackageReference Include="Dapplo.Windows.Icons" Version="2.0.83" />
+    <PackageReference Include="Dapplo.Windows.Kernel32" Version="2.0.83" />
+    <PackageReference Include="Dapplo.Windows.Multimedia" Version="2.0.83" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="log4net" version="3.3.0" />


### PR DESCRIPTION
Open Greenshot with file argument was broken because AppRestartManager using a newer Dapplo version than Greenshot.Base.