### PR TITLE
Redefine ImageContainer shadow

### DIFF
--- a/src/Greenshot.Editor/Drawing/ImageContainer.cs
+++ b/src/Greenshot.Editor/Drawing/ImageContainer.cs
@@ -211,9 +211,9 @@ namespace Greenshot.Editor.Drawing
                 // add an offset so it looks more like the other container.
                 var shadowOffset = 1;
                 // we use only the alpha value of the shadowPen, but we have to define line thickness 
-                var unusedShadowLinethickness = 1;           
+                var unusedShadowLinethickness = 1;
 
-                DrawShadow(unusedShadowLinethickness, (alpha, currentStep, shadowPen, nil) =>
+                DrawShadow(unusedShadowLinethickness, (alpha, currentStep, shadowPen, _) =>
                 {
                     var rect = new NativeRect(
                         Left + currentStep + shadowOffset,
@@ -226,8 +226,8 @@ namespace Greenshot.Editor.Drawing
 
                 });
             }
-                
-            graphics.DrawImage(_image, Bounds);            
+
+            graphics.DrawImage(_image, Bounds);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Greenshot.Editor.Drawing
         /// (fully opaque).</param>
         private void DrawImageWithAlpha(Graphics graphics, Image image, Rectangle bounds, byte alpha)
         {
-            // nomalize alpha from (0-255) to (0.0 - 1.0)
+            // normalize alpha from (0-255) to (0.0 - 1.0)
             float normalizedAlpha = alpha / 255f;
 
             var matrix = new ColorMatrix


### PR DESCRIPTION
Now the ImageContainer uses the same mechanism for drawing shadows as the other containers.

I'm still creating an internal shadow bitmap, but using a MonochromeEffect instead of a DropShadowEffect.
The shadow bitmap is only created when it's absolutely necessary. On first drawing attempt.

This fixes #1006 .
The size of the container no longer changes when you toggle the shadow button.

Here is a comparison of the old and new shadows (original left , with shadow right).
Old:
<img width="582" height="508" alt="image_shadow_test" src="https://github.com/user-attachments/assets/b5af748c-f300-4548-838b-0874496095c8" />

New:
<img width="582" height="508" alt="image_shadow_test_new" src="https://github.com/user-attachments/assets/27d1cfe3-78f9-4c52-8022-68f650abfad9" />
