### PR TITLE
Update OneNoteExporter.cs issues/1072

### DIFF
--- a/src/Greenshot.Plugin.Office/OfficeExport/OneNoteExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/OneNoteExporter.cs
@@ -257,7 +257,7 @@ namespace Greenshot.Plugin.Office.OfficeExport
                                         Name = xmlReader.GetAttribute("name"),
                                         Id = xmlReader.GetAttribute("ID")
                                     };
-                                    if ((page.Id == null) || (page.Name == null))
+                                    if ((page.Id == null) || (page.Name == null) || (page.Parent == null) || (page.Parent.Parent == null))
                                     {
                                         continue;
                                     }


### PR DESCRIPTION
Pages were being added to the list without verifying that their parent hierarchy was fully populated. If a page's section or notebook was null, DisplayName would crash accessing Parent.Parent.Name when the menu expanded. The fix skips any pages with an incomplete parent chain during parsing.

Fixes https://github.com/greenshot/greenshot/issues/1072