### PR TITLE
Fixing a root cause not a symptom in Office

### DIFF
--- a/src/Greenshot.Plugin.Office/OfficeExport/ExcelExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/ExcelExporter.cs
@@ -56,7 +56,16 @@ namespace Greenshot.Plugin.Office.OfficeExport
 
             if (excelApplication?.ComObject != null)
             {
-                InitializeVariables(excelApplication);
+                try
+                {
+                    InitializeVariables(excelApplication);
+                }
+                catch (InvalidCastException ex)
+                {
+                    LOG.Warn("Excel COM object is unusable due to a type library error — treating Excel as unavailable.", ex);
+                    excelApplication.Dispose();
+                    return null;
+                }
             }
 
             return excelApplication;
@@ -74,7 +83,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 excelApplication = DisposableCom.Create(new Application());
             }
 
-            InitializeVariables(excelApplication);
+            try
+            {
+                InitializeVariables(excelApplication);
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Excel COM object is unusable due to a type library error — treating Excel as unavailable.", ex);
+                excelApplication.Dispose();
+                return null;
+            }
+
             return excelApplication;
         }
 
@@ -120,10 +139,11 @@ namespace Greenshot.Plugin.Office.OfficeExport
                     _excelVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
                 }
             }
-            catch (InvalidCastException ex)
+            catch (InvalidCastException)
             {
-                LOG.Warn("Failed to get Excel version via COM (possible type library mismatch), assuming minimum.", ex);
-                _excelVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                // TYPE_E_CANTLOADLIBRARY: the COM object is entirely unusable. Re-throw so callers
+                // can treat Excel as unavailable rather than returning a broken COM object.
+                throw;
             }
         }
 

--- a/src/Greenshot.Plugin.Office/OfficeExport/OutlookEmailExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/OutlookEmailExporter.cs
@@ -580,7 +580,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 outlookApplication = DisposableCom.Create(new Application());
             }
 
-            InitializeVariables(outlookApplication);
+            try
+            {
+                InitializeVariables(outlookApplication);
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Outlook COM object is unusable due to a type library error — treating Outlook as unavailable.", ex);
+                outlookApplication.Dispose();
+                return null;
+            }
+
             return outlookApplication;
         }
 
@@ -603,7 +613,16 @@ namespace Greenshot.Plugin.Office.OfficeExport
 
             if ((outlookApplication != null) && (outlookApplication.ComObject != null))
             {
-                InitializeVariables(outlookApplication);
+                try
+                {
+                    InitializeVariables(outlookApplication);
+                }
+                catch (InvalidCastException ex)
+                {
+                    LOG.Warn("Outlook COM object is unusable due to a type library error — treating Outlook as unavailable.", ex);
+                    outlookApplication.Dispose();
+                    return null;
+                }
             }
 
             return outlookApplication;
@@ -689,10 +708,11 @@ namespace Greenshot.Plugin.Office.OfficeExport
                     _outlookVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
                 }
             }
-            catch (InvalidCastException ex)
+            catch (InvalidCastException)
             {
-                LOG.Warn("Failed to get Outlook version via COM (possible type library mismatch), assuming minimum.", ex);
-                _outlookVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                // TYPE_E_CANTLOADLIBRARY: the COM object is entirely unusable. Re-throw so callers
+                // can treat Outlook as unavailable rather than returning a broken COM object.
+                throw;
             }
 
             // Preventing retrieval of currentUser if Outlook is older than 2007

--- a/src/Greenshot.Plugin.Office/OfficeExport/PowerpointExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/PowerpointExporter.cs
@@ -236,7 +236,17 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 powerPointApplication = DisposableCom.Create(new Application());
             }
 
-            InitializeVariables(powerPointApplication);
+            try
+            {
+                InitializeVariables(powerPointApplication);
+            }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("PowerPoint COM object is unusable due to a type library error — treating PowerPoint as unavailable.", ex);
+                powerPointApplication.Dispose();
+                return null;
+            }
+
             return powerPointApplication;
         }
 
@@ -259,7 +269,16 @@ namespace Greenshot.Plugin.Office.OfficeExport
 
             if (powerPointApplication?.ComObject != null)
             {
-                InitializeVariables(powerPointApplication);
+                try
+                {
+                    InitializeVariables(powerPointApplication);
+                }
+                catch (InvalidCastException ex)
+                {
+                    LOG.Warn("PowerPoint COM object is unusable due to a type library error — treating PowerPoint as unavailable.", ex);
+                    powerPointApplication.Dispose();
+                    return null;
+                }
             }
 
             return powerPointApplication;
@@ -323,10 +342,11 @@ namespace Greenshot.Plugin.Office.OfficeExport
                     _powerpointVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
                 }
             }
-            catch (InvalidCastException ex)
+            catch (InvalidCastException)
             {
-                LOG.Warn("Failed to get PowerPoint version via COM (possible type library mismatch), assuming minimum.", ex);
-                _powerpointVersion = new Version((int) OfficeVersions.Office97, 0, 0, 0);
+                // TYPE_E_CANTLOADLIBRARY: the COM object is entirely unusable. Re-throw so callers
+                // can treat PowerPoint as unavailable rather than returning a broken COM object.
+                throw;
             }
         }
 

--- a/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
+++ b/src/Greenshot.Plugin.Office/OfficeExport/WordExporter.cs
@@ -75,6 +75,12 @@ namespace Greenshot.Plugin.Office.OfficeExport
             {
                 InitializeVariables(wordApplication);
             }
+            catch (InvalidCastException ex)
+            {
+                LOG.Warn("Word COM object is unusable due to a type library error — treating Word as unavailable.", ex);
+                wordApplication.Dispose();
+                return null;
+            }
             catch (Exception ex)
             {
                 LOG.Warn("Unable to initialize Word variables, assuming Word version 1997.", ex);
@@ -111,6 +117,12 @@ namespace Greenshot.Plugin.Office.OfficeExport
                 try
                 {
                     InitializeVariables(wordApplication);
+                }
+                catch (InvalidCastException ex)
+                {
+                    LOG.Warn("Word COM object is unusable due to a type library error — treating Word as unavailable.", ex);
+                    wordApplication.Dispose();
+                    return null;
                 }
                 catch (Exception ex)
                 {
@@ -174,9 +186,12 @@ namespace Greenshot.Plugin.Office.OfficeExport
                     _wordVersion = null;
                 }
             }
-            catch (InvalidCastException ex)
+            catch (InvalidCastException)
             {
-                LOG.Warn("Failed to get Word version via COM (possible type library mismatch), assuming minimum.", ex);
+                // TYPE_E_CANTLOADLIBRARY: the Office type library cannot be loaded, meaning this COM object is
+                // entirely unusable (every call will fail the same way). Re-throw so callers can treat the
+                // application as unavailable rather than returning a broken COM object.
+                throw;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The previous fix caught InvalidCastException in InitializeVariables and fell back to a default version — treating a broken COM object as if it were a usable one. The root cause is TYPE_E_CANTLOADLIBRARY: when the Office type library can't be loaded, every subsequent COM call on that object will fail the same way, not just .Version. The correct fix is to re-throw InvalidCastException from InitializeVariables and handle it in the callers (GetWordApplication, etc.) by disposing the broken COM object and returning null — so Greenshot treats the Office application as unavailable rather than attempting to use an object it fundamentally cannot interface with.

This came from and fixes https://github.com/greenshot/greenshot/issues/1061