### PR TITLE
Fix uninstall old versions

### DIFF
--- a/src/Greenshot-Installer/setup.iss
+++ b/src/Greenshot-Installer/setup.iss
@@ -597,6 +597,37 @@ begin
 	Result := asUninstallStrings;
 end;
 
+/////////////////////////////////////////////////////////////////////
+procedure UnInstallOldVersions();
+var
+	sUnInstallString: String;
+	index: Integer;
+	isUninstallMade: Boolean;
+	iResultCode : Integer;
+	asUninstallStrings : array of String;
+begin
+	isUninstallMade := false;
+	asUninstallStrings := GetUninstallStrings();
+	for index := 0 to (GetArrayLength(asUninstallStrings) -1) do
+	begin
+		sUnInstallString := RemoveQuotes(asUninstallStrings[index]);
+		if Exec(sUnInstallString, '/SILENT /NORESTART /SUPPRESSMSGBOXES','', SW_HIDE, ewWaitUntilTerminated, iResultCode) then
+			isUninstallMade := true;
+	end;
+
+	// Wait a few seconds to prevent installation issues, otherwise files are removed in one process while the other tries to link to them
+	if (isUninstallMade) then
+		Sleep(2000);
+end;
+
+/////////////////////////////////////////////////////////////////////
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+	if (CurStep=ssInstall) then
+	begin
+		UnInstallOldVersions();
+	end;
+end;
 
 /////////////////////////////////////////////////////////////////////
 // End of unstall code


### PR DESCRIPTION
@Lakritzator  I think i found the reason why old plugins (Win10, ...) are still present after an update.

It happens since v1.4.143.

With commit https://github.com/greenshot/greenshot/pull/1000/changes/57692e3b982f323dde53dce7bfefafdb328f6f35#diff-b1adc65b08ec5ee452d941e818386b35250dbeb90572ed5ac4f93f05f69914bc   the function  `UnInstallOldVersions()` was deleted in `setup.iss`.

Comment there:

> This fixes some of the issues in the installer, although Restart Manager was used, the installer checkedvia the Mutex if the application was running. 
> 
> Also it was running the uninstall before the application was closed. 
> 
> Fixed issues with triggering the TryClose from the wrong thread. Still having issues that the  ApplicationRestartManager.ListenForEndSession().Subscribe doesn't seem to work.

It looks like it was temporarily removed and then forgetten to be re-added.

⚠️I just copied the old function back and haven't tested it yet. 

I'm not very familiar with the installer, but I thought you should at least have this information