### PR TITLE
Update ScaleHelper.cs to fix #1055

### DIFF
--- a/src/Greenshot.Editor/Helpers/ScaleHelper.cs
+++ b/src/Greenshot.Editor/Helpers/ScaleHelper.cs
@@ -243,9 +243,12 @@ namespace Greenshot.Editor.Helpers
 
             if (centeredScale)
             {
-                float wdiff = (result.Width - boundsBeforeResize.Width) / 2;
-                float hdiff = (result.Height - boundsBeforeResize.Height) / 2;
-                result = result.Inflate(wdiff, hdiff);
+                // The click point is the center: expand the result symmetrically around it.
+                // boundsBeforeResize.X/Y is the click origin (set in HandleMouseDown).
+                // result.Width/Height is the half-size (cursor distance from origin).
+                float halfW = result.Width;
+                float halfH = result.Height;
+                result = new NativeRectFloat(boundsBeforeResize.X - halfW, boundsBeforeResize.Y - halfH, halfW * 2, halfH * 2);
             }
 
             return result;


### PR DESCRIPTION
Replaced the broken Inflate-based centering with correct geometry: use result.Width/Height as the half-size from the click origin, then build {clickX - halfW, clickY - halfH, 2*halfW, 2*halfH}.

The old code computed wdiff = (result.Width - boundsBeforeResize.Width) / 2 which is always 0 when SHIFT isn't also held, making CTRL a no-op. The CTRL+SHIFT weirdness was the same bug manifesting differently.

Fixes https://github.com/greenshot/greenshot/issues/1055