### PR TITLE
Additional installer leftover delete

### DIFF
--- a/installer/innosetup/setup.iss
+++ b/installer/innosetup/setup.iss
@@ -767,7 +767,7 @@ Type: filesandordirs; Name: "{app}\Plugins\GreenshotOfficePlugin"
 Type: filesandordirs; Name: "{app}\Plugins\GreenshotPhotobucketPlugin"
 Type: filesandordirs; Name: "{app}\Plugins\GreenshotPicasaPlugin"
 
-// Newer 1.3 plugins
+// Portable plugin directories
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Box"
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Confluence"
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Dropbox"
@@ -779,6 +779,19 @@ Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Jira"
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Office"
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Photobucket"
 Type: filesandordirs; Name: "{app}\Plugins\Greenshot.Plugin.Win10"
+
+// Newer 1.3 plugins
+Type: filesandordirs; Name: "{app}\Plugins\Box"
+Type: filesandordirs; Name: "{app}\Plugins\Confluence"
+Type: filesandordirs; Name: "{app}\Plugins\Dropbox"
+Type: filesandordirs; Name: "{app}\Plugins\ExternalCommand"
+Type: filesandordirs; Name: "{app}\Plugins\Flickr"
+Type: filesandordirs; Name: "{app}\Plugins\GooglePhotos"
+Type: filesandordirs; Name: "{app}\Plugins\Imgur"
+Type: filesandordirs; Name: "{app}\Plugins\Jira"
+Type: filesandordirs; Name: "{app}\Plugins\Office"
+Type: filesandordirs; Name: "{app}\Plugins\Photobucket"
+Type: filesandordirs; Name: "{app}\Plugins\Win10"
 
 // Cleanup directory if there are no plugins left
 Name: {app}\Plugins; Type: dirifempty;


### PR DESCRIPTION
As noticed by @Christian-Schulz the directories weren't complete, the 1.3 mentioned were in fact from the portable...
This fix includes the 1.3 directories.