### PR TITLE
Fix for - Unable to retrieve the root folder

### DIFF
--- a/src/Greenshot/Configuration/LanguageKeys.cs
+++ b/src/Greenshot/Configuration/LanguageKeys.cs
@@ -70,6 +70,8 @@ namespace Greenshot.Configuration
         settings_tooltip_language,
         settings_tooltip_primaryimageformat,
         settings_tooltip_storagelocation,
+        settings_storagelocation_folder_error,
+        settings_storagelocation_folder_error_title,
         settings_visualization,
         settings_window_capture_mode,
         tooltip_firststart,

--- a/src/Greenshot/Forms/SettingsForm.cs
+++ b/src/Greenshot/Forms/SettingsForm.cs
@@ -666,9 +666,14 @@ namespace Greenshot.Forms
             }
             catch (InvalidOperationException ex)
             {
-                Log.Warn("Problem opening folder browser dialog, retrying with empty path: ", ex);
-                // Retry with an empty SelectedPath so the user can still browse and correct the path
-                folderBrowserDialog1.SelectedPath = string.Empty;
+                // This can happen when Greenshot was launched under a system/service account (e.g. after an
+                // IT-managed silent install) and the shell cannot resolve the default root folder for the
+                // current user context. Retry rooted at MyComputer with a known-good user folder so the
+                // user can still pick a destination.
+                Log.Warn("Problem opening folder browser dialog, retrying with user profile fallback: ", ex);
+                string fallbackPath = GetAccessibleFallbackPath();
+                folderBrowserDialog1.SelectedPath = fallbackPath;
+                folderBrowserDialog1.RootFolder = Environment.SpecialFolder.MyComputer;
                 try
                 {
                     if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
@@ -678,9 +683,45 @@ namespace Greenshot.Forms
                 }
                 catch (InvalidOperationException retryEx)
                 {
-                    Log.Error("Failed to open folder browser dialog even with empty path: ", retryEx);
+                    Log.Error("Failed to open folder browser dialog even with fallback path: ", retryEx);
+                    // Last resort: populate the textbox with the fallback path so the user at least
+                    // has a valid, writable destination rather than a red invalid-path indicator.
+                    if (!string.IsNullOrEmpty(fallbackPath))
+                    {
+                        textbox_storagelocation.Text = fallbackPath;
+                        MessageBox.Show(
+                            Language.GetString(LangKey.settings_storagelocation_folder_error),
+                            Language.GetString(LangKey.settings_storagelocation_folder_error_title),
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Information);
+                    }
+                }
+                finally
+                {
+                    folderBrowserDialog1.RootFolder = Environment.SpecialFolder.Desktop;
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns the first accessible path suitable as a fallback storage location when the folder
+        /// browser dialog cannot resolve the shell root (e.g. process started under a system account).
+        /// Tries MyDocuments, Desktop, and TEMP in order.
+        /// </summary>
+        private static string GetAccessibleFallbackPath()
+        {
+            var candidates = new[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Path.GetTempPath()
+            };
+            foreach (string candidate in candidates)
+            {
+                if (!string.IsNullOrEmpty(candidate) && Directory.Exists(candidate))
+                    return candidate;
+            }
+            return string.Empty;
         }
 
         private void TrackBarJpegQualityScroll(object sender, EventArgs e)

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -292,6 +292,10 @@ time, e.g. 11_58_32 (plus extension defined in the settings)</resource>
 		<resource name="settings_tooltip_primaryimageformat">Image format used by default</resource>
 		<resource name="settings_tooltip_registerhotkeys">Defines whether the shortcuts Prnt, Ctrl + Print, Alt + Prnt are reserved for global use by Greenshot at program startup, until the program is shut down.</resource>
 		<resource name="settings_tooltip_storagelocation">Location where screenshots are stored by default (leave empty for saving to your desktop)</resource>
+		<resource name="settings_storagelocation_folder_error">The folder browser could not be opened.
+
+The storage location has been set to your Documents folder. You can type a different path directly into the box if needed.</resource>
+		<resource name="settings_storagelocation_folder_error_title">Storage Location</resource>
 		<resource name="settings_usedefaultproxy">Use default system proxy</resource>
 		<resource name="settings_visualization">Effects</resource>
 		<resource name="settings_waittime">Milliseconds to wait before capture</resource>


### PR DESCRIPTION
This PR addresses a real-world pain point reported by users in IT-managed environments where Greenshot is silently installed or updated under a system/service account. When the end user subsequently opens Settings and clicks the browse button for the storage location, the Windows shell fails to resolve the root folder for the system account context, throwing System.InvalidOperationException: Unable to retrieve the root folder and leaving the user with a red invalid-path box and no way forward.

Rather than attempting to fix the deeper process-context issue (which is out of scope), this fix hardens the BrowseClick handler with a graceful degradation strategy: on the first failure it retries the dialog rooted at MyComputer — which doesn't require a user profile to resolve — seeded with the current interactive user's MyDocuments path via Environment.GetFolderPath, which correctly resolves against the logged-in user's token regardless of the account Greenshot started under. If the dialog still cannot open, rather than leaving the user stuck, it populates the storage location textbox with the first accessible user folder found (Documents → Desktop → Temp) and shows a localised informational message explaining what happened. The fix is entirely contained within the catch path so zero behaviour changes for normal users, and the two new language keys (settings_storagelocation_folder_error / settings_storagelocation_folder_error_title) follow the existing localisation pattern so translations can be contributed in the usual way.

Fixes a massive pain point - #1040 #894 #785 #1090