### PR TITLE
Update ToastNotificationService.cs to fix #758

### DIFF
--- a/src/Greenshot/Native/ToastNotificationService.cs
+++ b/src/Greenshot/Native/ToastNotificationService.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Threading.Tasks;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
 using Windows.UI.Notifications;
@@ -107,18 +108,25 @@ namespace Greenshot.Plugin.Win10
                 return;
             }
 
-            // Here is an interesting article on reading the settings: https://www.rudyhuyn.com/blog/2018/02/10/toastnotifier-and-settings-careful-with-non-uwp-applications/
             try
             {
-                if (toastNotifier.Setting != NotificationSetting.Enabled)
+                var settingTask = Task.Run(() => toastNotifier.Setting);
+                if (settingTask.Wait(TimeSpan.FromMilliseconds(500)))
                 {
-                    Log.DebugFormat("Ignored toast due to {0}", toastNotifier.Setting);
-                    return;
+                    if (settingTask.Result != NotificationSetting.Enabled)
+                    {
+                        Log.DebugFormat("Ignored toast due to {0}", settingTask.Result);
+                        return;
+                    }
+                }
+                else
+                {
+                    Log.Warn("Timed out reading toast notification setting; skipping setting check.");
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Log.Info("Ignoring exception as this means that there was no stored settings.");
+                Log.WarnFormat("Exception reading toast notification setting, skipping check: {0}", ex.Message);
             }
 
             try


### PR DESCRIPTION
Here goes..... - Accessing toastNotifier.Setting performs a synchronous WinRT COM interop call that marshals into the Windows notification subsystem.

On certain Windows 11 24H2 builds (observed around 26200.7462–26200.7840), a regression in the notification platform — sometimes exacerbated by security software intercepting COM calls — causes this synchronous call to block indefinitely, deadlocking the UI thread and making the entire Greenshot window unresponsive.

Because the call is inherently synchronous in the WinRT projection, we can't make it truly async, so instead we run it on a ThreadPool thread via Task.Run and impose a 500ms timeout.

On a healthy system, the call returns in single-digit milliseconds, so 500ms is a generous safety margin, but it means a user on a broken notification subsystem waits at most half a second before Greenshot's UI is usable again rather than hanging indefinitely.

If the call completes in time, we act on the result normally; if it times out or throws, we log a warning and skip the setting check, falling through to attempt the toast anyway.

The fix is not specific to Windows 11 24H2 — because it offloads the blocking WinRT call off the UI thread entirely, it will protect against any future OS regression or security software interaction that causes the same hang, regardless of Windows version.

Fixes #758