### PR TITLE
Ability to close v1.3 with v1.4 installer

### DIFF
--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -928,16 +928,34 @@ namespace Greenshot.Editor.Forms
             UpdateUndoRedoSurfaceDependencies();
         }
 
+        private static bool IsExternalShutdownCloseReason(CloseReason closeReason)
+        {
+            return closeReason == CloseReason.ApplicationExitCall || closeReason == CloseReason.WindowsShutDown || closeReason == CloseReason.TaskManagerClosing;
+        }
+
+        // only for workaround for the installer from 1.3 to 1.4.
+        private bool _closeWithoutSavePrompt;
+
         private void ImageEditorFormFormClosing(object sender, FormClosingEventArgs e)
         {
-            if (_surface.Modified && !EditorConfiguration.SuppressSaveDialogAtClose)
+            void ForceCloseWithoutPrompt () 
+            {
+                // only for workaround for the installer from 1.3 to 1.4.
+                // When the installer tries to close the editor and the closing takes too long, the installer cancels the outer closing process
+                // So we force the closing without prompt again and the editor will not be in a wierd state
+                e.Cancel = true;
+                _closeWithoutSavePrompt = true;
+                BeginInvoke((MethodInvoker)delegate { Close(); });
+            };
+
+            if (!_closeWithoutSavePrompt && _surface.Modified && !EditorConfiguration.SuppressSaveDialogAtClose)
             {
                 // Make sure the editor is visible
                 WindowDetails.ToForeground(Handle);
 
                 MessageBoxButtons buttons = MessageBoxButtons.YesNoCancel;
                 // Dissallow "CANCEL" if the application needs to shutdown
-                if (e.CloseReason == CloseReason.ApplicationExitCall || e.CloseReason == CloseReason.WindowsShutDown || e.CloseReason == CloseReason.TaskManagerClosing)
+                if (IsExternalShutdownCloseReason(e.CloseReason))
                 {
                     buttons = MessageBoxButtons.YesNo;
                 }
@@ -959,6 +977,17 @@ namespace Greenshot.Editor.Forms
                         e.Cancel = true;
                         return;
                     }
+
+                    if (IsExternalShutdownCloseReason(e.CloseReason))
+                    {
+                        ForceCloseWithoutPrompt();
+                        return;
+                    }
+                }
+                else if (result.Equals(DialogResult.No) && IsExternalShutdownCloseReason(e.CloseReason))
+                {
+                    ForceCloseWithoutPrompt();
+                    return;
                 }
             }
 

--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -36,6 +36,7 @@ using Dapplo.Windows.Common.Structs;
 using Dapplo.Windows.DesktopWindowsManager;
 using Dapplo.Windows.Dpi;
 using Dapplo.Windows.Kernel32;
+using Dapplo.Windows.Messages.Enumerations;
 using Dapplo.Windows.User32;
 using Greenshot.Base;
 using Greenshot.Base.Controls;
@@ -661,6 +662,15 @@ namespace Greenshot.Forms
             if (WmInputLangChangeRequestFilter.PreFilterMessageExternal(ref m))
             {
                 return;
+            }
+
+            WindowsMessages message = (WindowsMessages)m.Msg;
+            if (message == WindowsMessages.WM_DESTROY)
+            {
+                LOG.InfoFormat(" Message {0} ( {1:X} - {2:X} - {3:X}) send, Exit Application.", m, m.LParam.ToInt64(), m.WParam.ToInt64(), m.HWnd.ToInt64());
+                // is send from Inno Setup, when the user chooses to exit Greenshot during installation
+                // TODO Only for Greenshot versions before integration of RestartManager
+                Exit();
             }
 
             base.WndProc(ref m);


### PR DESCRIPTION
This is a PR only for v1.3.
If you have v1.3 installed and use the installer from v1.4.163+ Inno Setup tries to close Greenshot. 
But it closes not all. The UI thread and system tray icon is gone and the Hotkey is unregistered. Some threads are left.

At first I thought it was the UpdateService and I spent a lot of time tweaking the service, but that wasn't necessary. It wasn't the only thread. I couldn't identify the last other one.

I'll create a separate PR for my changes to the UpdateService in the dev branch.

Inno Setup uses the Windows Restart Manager. Since Greenshot v1.3 is not registered, Windows sends a `WM_DESTROY` message.

I reacted to this and call `Exit()` manually.

I'am not 100% sure if this is the right way, so i marked it as draft. 

- It works if no Editor is open. v1.3 is terminated and the last step of the Installer starts v1.4.163+
- It works if all open Editors have no modified content.
- It works if an Editor has modified content, you see the save question dialog and you save it.
- it don't work if an Editor has modified content and you are not fast enough to save it. (there is a timeout in the Installer)
- it don't work if an Editor has modified content and you cancel the save question dialog.