### PR TITLE
Fix for - Cross thread exception (RPC_E_WRONG_THREAD) on get toastNotifier.Setting on Windows 10

### DIFF
--- a/src/Greenshot/Native/ToastNotificationService.cs
+++ b/src/Greenshot/Native/ToastNotificationService.cs
@@ -22,7 +22,7 @@
 using System;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Threading.Tasks;
+using System.Threading;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
 using Windows.UI.Notifications;
@@ -95,38 +95,11 @@ namespace Greenshot.Plugin.Win10
                 return;
             }
 
-            // Prepare the toast notifier. Be sure to specify the AppUserModelId on your application's shortcut!
-            Microsoft.Toolkit.Uwp.Notifications.ToastNotifierCompat toastNotifier = null;
-            try
+            // Do not inform the user if ToastNotification is not enabled
+            if (!IsToastNotificationEnabled()
+            )
             {
-                toastNotifier = ToastNotificationManagerCompat.CreateToastNotifier();
-            }
-            catch (Exception ex)
-            {
-                Log.Warn("Could not create a toast notifier.", ex);
-
                 return;
-            }
-
-            try
-            {
-                var settingTask = Task.Run(() => toastNotifier.Setting);
-                if (settingTask.Wait(TimeSpan.FromMilliseconds(500)))
-                {
-                    if (settingTask.Result != NotificationSetting.Enabled)
-                    {
-                        Log.DebugFormat("Ignored toast due to {0}", settingTask.Result);
-                        return;
-                    }
-                }
-                else
-                {
-                    Log.Warn("Timed out reading toast notification setting; skipping setting check.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.WarnFormat("Exception reading toast notification setting, skipping check: {0}", ex.Message);
             }
 
             try
@@ -140,8 +113,8 @@ namespace Greenshot.Plugin.Win10
                     //.AddAppLogoOverride(new Uri($@"file://{_imageFilePath}"), ToastGenericAppLogoCrop.None)
                     .Show(toast =>
                     {
-                    // Windows 10 first with 1903: ExpiresOnReboot = true
-                    toast.ExpirationTime = timeout.HasValue ? DateTimeOffset.Now.Add(timeout.Value) : (DateTimeOffset?)null;
+                        // Windows 10 first with 1903: ExpiresOnReboot = true
+                        toast.ExpirationTime = timeout.HasValue ? DateTimeOffset.Now.Add(timeout.Value) : (DateTimeOffset?)null;
 
                         void ToastActivatedHandler(ToastNotification toastNotification, object sender)
                         {
@@ -180,15 +153,14 @@ namespace Greenshot.Plugin.Win10
                             }
 
                             toast.Dismissed -= ToastDismissedHandler;
-                        // Remove the other handler too
-                        toast.Activated -= ToastActivatedHandler;
+                            // Remove the other handler too
+                            toast.Activated -= ToastActivatedHandler;
                             toast.Failed -= ToastOnFailed;
                         }
 
                         toast.Dismissed += ToastDismissedHandler;
                         toast.Failed += ToastOnFailed;
                     });
-
             }
             catch (Exception ex)
             {
@@ -231,6 +203,55 @@ namespace Greenshot.Plugin.Win10
             Log.Warn("ToastNotificationActionTrigger not available.");
 
             return null;
+        }
+
+        private bool IsToastNotificationEnabled()
+        {
+            try
+            {
+                var toastNotifierCreated = false;
+                var setting = NotificationSetting.DisabledForApplication;
+
+                var thread = new Thread(() =>
+                {
+                    // Prepare the toast notifier. Be sure to specify the AppUserModelId on your application's shortcut!
+                    ToastNotifierCompat toastNotifier = null;
+                    try
+                    {
+                        toastNotifier = ToastNotificationManagerCompat.CreateToastNotifier();
+                        toastNotifierCreated = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warn("Could not create a toast notifier.", ex);
+                        toastNotifierCreated = false;
+                    }
+                    setting = toastNotifier.Setting;
+                });
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+
+                var completed = thread.Join(500);
+                if (!completed)
+                {
+                    Log.Warn("Timed out reading toast notification setting; skipping setting check.");
+                }
+                else if (!toastNotifierCreated)
+                {
+                    return false;
+                }
+                else if (setting != NotificationSetting.Enabled)
+                {
+                    Log.DebugFormat("Ignored toast due to {0}", setting);
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.WarnFormat("Exception reading toast notification setting, skipping check: {0}", ex.Message);
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
When running locally in debug mode - right after capturing a screen region and sending into the Editor - I encountered a cross-thread operation in **ToastNotificationService.cs** (which is actually only logged and skipped).

<img width="1153" height="363" alt="image" src="https://github.com/user-attachments/assets/123f51f8-a8da-46b5-9607-722357e8b893" />

The exception was:
```console
System.Exception
  HResult=0x8001010E
  Message=The application called an interface that was marshaled for a different thread. (Exception from HRESULT: 0x8001010E (RPC_E_WRONG_THREAD))
```
with the following call stack:
```console
  | [System.Exception thrown]
  | [Managed to Native Transition]
> | Greenshot.exe!Greenshot.Plugin.Win10.ToastNotificationService.ShowMessage.AnonymousMethod__1() Line 118
  | mscorlib.dll!System.Threading.Tasks.Task<>.InnerInvoke()
  | mscorlib.dll!System.Threading.Tasks.Task.Execute()
  | mscorlib.dll!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)
  | mscorlib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)
  | mscorlib.dll!System.Threading.Tasks.Task.ExecuteWithThreadLocal(ref System.Threading.Tasks.Task currentTaskSlot)
  | mscorlib.dll!System.Threading.Tasks.Task.ExecuteEntry(bool bPreventDoubleExecution)
  | mscorlib.dll!System.Threading.ThreadPoolWorkQueue.Dispatch()
```

Seems like it can be fixed by using a standard Dispatcher.Invoke.