### PR TITLE
Update ToolStripNumericUpDown.cs

### DIFF
--- a/src/Greenshot.Editor/Controls/ToolStripNumericUpDown.cs
+++ b/src/Greenshot.Editor/Controls/ToolStripNumericUpDown.cs
@@ -42,7 +42,7 @@ namespace Greenshot.Editor.Controls
         public decimal Value
         {
             get { return NumericUpDown.Value; }
-            set { NumericUpDown.Value = value; }
+            set { NumericUpDown.Value = Math.Min(NumericUpDown.Maximum, Math.Max(NumericUpDown.Minimum, value)); }
         }
 
         public decimal Minimum

--- a/src/Greenshot.Editor/Controls/ToolStripNumericUpDown.cs
+++ b/src/Greenshot.Editor/Controls/ToolStripNumericUpDown.cs
@@ -42,7 +42,12 @@ namespace Greenshot.Editor.Controls
         public decimal Value
         {
             get { return NumericUpDown.Value; }
-            set { NumericUpDown.Value = Math.Min(NumericUpDown.Maximum, Math.Max(NumericUpDown.Minimum, value)); }
+            set
+            {
+                var control = NumericUpDown;
+                var clampedValue = Math.Min(control.Maximum, Math.Max(control.Minimum, value));
+                control.Value = clampedValue;
+            }
         }
 
         public decimal Minimum


### PR DESCRIPTION
Clamps the incoming value to the control's [Minimum, Maximum] range in ToolStripNumericUpDown.set_Value so out-of-range field values (e.g. a persisted LINE_THICKNESS of 103 against a max of 100) are silently clamped rather than throwing ArgumentOutOfRangeException. Fixes #1142