### PR TITLE
Fix High DPI scaling behavior and hide legacy icon size settings

### DIFF
--- a/src/Greenshot.Base/Core/AbstractDestination.cs
+++ b/src/Greenshot.Base/Core/AbstractDestination.cs
@@ -178,7 +178,7 @@ namespace Greenshot.Base.Core
             ExportInformation exportInformation = new ExportInformation(Designation, Language.GetString("settings_destination_picker"));
             var menu = new ContextMenuStrip
             {
-                ImageScalingSize = CoreConfig.IconSize,
+                ImageScalingSize = CoreConfig.MenuIconSize,
                 Tag = null,
                 TopLevel = true,
                 Font = new Font(FontFamily.GenericSansSerif, 9) // set new default font, so we are allowed to dispose it later, we will scale it later on the Opening event
@@ -188,7 +188,7 @@ namespace Greenshot.Base.Core
             {
                 // find the DPI settings for the screen where this is going to land
                 var screenDpi = NativeDpiMethods.GetDpi(menu.Location);
-                var scaledIconSize = DpiCalculator.ScaleWithDpi(CoreConfig.IconSize, screenDpi);
+                var scaledIconSize = DpiCalculator.ScaleWithDpi(CoreConfig.MenuIconSize, screenDpi);
                 menu.SuspendLayout();
                 var fontSize = DpiCalculator.ScaleWithDpi(12f, screenDpi);
                 var previousFont = menu.Font;

--- a/src/Greenshot.Base/Core/CoreConfiguration.cs
+++ b/src/Greenshot.Base/Core/CoreConfiguration.cs
@@ -316,47 +316,79 @@ namespace Greenshot.Base.Core
         [IniProperty("Win10BorderCrop", Description = "The capture is cropped with these settings, e.g. when you don't want to color around it -1,-1"), DefaultValue("0,0")]
         public NativeSize Win10BorderCrop { get; set; }
 
-        private NativeSize _iconSize;
+        private NativeSize _editorIconSize;
+        private NativeSize _menuIconSize;
+
+        private NativeSize NormalizeIconSize(Size value)
+        {
+            Size newSize = value;
+            if (newSize == Size.Empty)
+            {
+                return newSize;
+            }
+
+            if (newSize.Width < 16)
+            {
+                newSize.Width = 16;
+            }
+            else if (newSize.Width > 256)
+            {
+                newSize.Width = 256;
+            }
+
+            newSize.Width = (newSize.Width / 16) * 16;
+            if (newSize.Height < 16)
+            {
+                newSize.Height = 16;
+            }
+            else if (newSize.Height > 256)
+            {
+                newSize.Height = 256;
+            }
+
+            newSize.Height = (newSize.Height / 16) * 16;
+            return newSize;
+        }
 
         [IniProperty("BaseIconSize",
-            Description = "Defines the base size of the icons (e.g. for the buttons in the editor), default value 16,16 and it's scaled to the current DPI",
+            Description = "Defines the base size of the editor icons, default value 16,16 and it's scaled to the current DPI",
             DefaultValue = "16,16")]
         public NativeSize IconSize
         {
-            get { return _iconSize; }
+            get { return _editorIconSize; }
             set
             {
-                Size newSize = value;
-                if (newSize != Size.Empty)
+                var newSize = NormalizeIconSize(value);
+                if (_editorIconSize != newSize)
                 {
-                    if (newSize.Width < 16)
-                    {
-                        newSize.Width = 16;
-                    }
-                    else if (newSize.Width > 256)
-                    {
-                        newSize.Width = 256;
-                    }
-
-                    newSize.Width = (newSize.Width / 16) * 16;
-                    if (newSize.Height < 16)
-                    {
-                        newSize.Height = 16;
-                    }
-                    else if (newSize.Height > 256)
-                    {
-                        newSize.Height = 256;
-                    }
-
-                    newSize.Height = (newSize.Height / 16) * 16;
-                }
-
-                if (_iconSize != newSize)
-                {
-                    _iconSize = newSize;
+                    _editorIconSize = newSize;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IconSize"));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(EditorIconSize)));
                 }
             }
+        }
+
+        [IniProperty("MenuBaseIconSize",
+            Description = "Defines the base size of the tray and popup menu icons, default value 16,16 and it's scaled to the current DPI",
+            DefaultValue = "16,16")]
+        public NativeSize MenuIconSize
+        {
+            get => _menuIconSize;
+            set
+            {
+                var newSize = NormalizeIconSize(value);
+                if (_menuIconSize != newSize)
+                {
+                    _menuIconSize = newSize;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MenuIconSize)));
+                }
+            }
+        }
+
+        public NativeSize EditorIconSize
+        {
+            get => IconSize;
+            set => IconSize = value;
         }
         
         [IniProperty("WebRequestTimeout", Description = "The connect timeout value for web requests, these are seconds", DefaultValue = "100")]
@@ -365,7 +397,7 @@ namespace Greenshot.Base.Core
         [IniProperty("WebRequestReadWriteTimeout", Description = "The read/write timeout value for web requests, these are seconds", DefaultValue = "100")]
         public int WebRequestReadWriteTimeout { get; set; }
 
-        public bool UseLargeIcons => IconSize.Width >= 32 || IconSize.Height >= 32;
+        public bool UseLargeIcons => EditorIconSize.Width >= 32 || EditorIconSize.Height >= 32;
 
         /// <summary>
         /// A helper method which returns true if the supplied experimental feature is enabled

--- a/src/Greenshot.Base/Core/CoreConfiguration.cs
+++ b/src/Greenshot.Base/Core/CoreConfiguration.cs
@@ -390,6 +390,11 @@ namespace Greenshot.Base.Core
             get => IconSize;
             set => IconSize = value;
         }
+
+        [IniProperty("IconSizeMigratedToAutoScaling",
+            Description = "Tracks one-time migration to automatic DPI icon scaling defaults.",
+            DefaultValue = "False")]
+        public bool IconSizeMigratedToAutoScaling { get; set; }
         
         [IniProperty("WebRequestTimeout", Description = "The connect timeout value for web requests, these are seconds", DefaultValue = "100")]
         public int WebRequestTimeout { get; set; }
@@ -653,6 +658,27 @@ namespace Greenshot.Base.Core
             if (WebRequestReadWriteTimeout < 1)
             {
                 WebRequestReadWriteTimeout = 100;
+            }
+
+            // One-time migration: manual icon base sizes break automatic DPI scaling.
+            // Force both icon bases to the default 16x16 and persist this once.
+            if (!IconSizeMigratedToAutoScaling)
+            {
+                var defaultIconSize = new Size(16, 16);
+                if (EditorIconSize != defaultIconSize)
+                {
+                    EditorIconSize = defaultIconSize;
+                    IsDirty = true;
+                }
+
+                if (MenuIconSize != defaultIconSize)
+                {
+                    MenuIconSize = defaultIconSize;
+                    IsDirty = true;
+                }
+
+                IconSizeMigratedToAutoScaling = true;
+                IsDirty = true;
             }
         }
 

--- a/src/Greenshot.Base/Core/PluginUtils.cs
+++ b/src/Greenshot.Base/Core/PluginUtils.cs
@@ -54,7 +54,7 @@ namespace Greenshot.Base.Core
         /// <param name="e"></param>
         private static void OnIconSizeChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != "IconSize") return;
+            if (e.PropertyName != nameof(CoreConfig.IconSize) && e.PropertyName != nameof(CoreConfig.MenuIconSize)) return;
             var cachedImages = new List<Image>();
             lock (ExeIconCache)
             {
@@ -158,7 +158,8 @@ namespace Greenshot.Base.Core
 
             try
             {
-                var appIcon = IconHelper.ExtractAssociatedIcon<Bitmap>(path, index, CoreConfig.UseLargeIcons);
+                var useLargeIcons = CoreConfig.MenuIconSize.Width >= 32 || CoreConfig.MenuIconSize.Height >= 32;
+                var appIcon = IconHelper.ExtractAssociatedIcon<Bitmap>(path, index, useLargeIcons);
                 if (appIcon != null)
                 {
                     Log.DebugFormat("Loaded icon for {0}, with dimensions {1}x{2}", path, appIcon.Width, appIcon.Height);

--- a/src/Greenshot.Base/Core/PluginUtils.cs
+++ b/src/Greenshot.Base/Core/PluginUtils.cs
@@ -54,7 +54,9 @@ namespace Greenshot.Base.Core
         /// <param name="e"></param>
         private static void OnIconSizeChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != nameof(CoreConfig.IconSize) && e.PropertyName != nameof(CoreConfig.MenuIconSize)) return;
+            if (e.PropertyName != nameof(CoreConfig.IconSize) &&
+                e.PropertyName != nameof(CoreConfig.EditorIconSize) &&
+                e.PropertyName != nameof(CoreConfig.MenuIconSize)) return;
             var cachedImages = new List<Image>();
             lock (ExeIconCache)
             {

--- a/src/Greenshot.Editor/Forms/ColorDialog.cs
+++ b/src/Greenshot.Editor/Forms/ColorDialog.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.Threading;
@@ -30,6 +31,7 @@ using Greenshot.Base.Controls;
 using Greenshot.Base.IniFile;
 using Greenshot.Editor.Configuration;
 using Greenshot.Editor.Controls;
+using log4net;
 
 namespace Greenshot.Editor.Forms
 {
@@ -38,7 +40,29 @@ namespace Greenshot.Editor.Forms
     /// </summary>
     public partial class ColorDialog : EditorForm
     {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(ColorDialog));
         private static readonly EditorConfiguration EditorConfig = IniConfig.GetIniSection<EditorConfiguration>();
+        private static readonly Color[] BasePaletteColumnColors =
+        {
+            Color.FromArgb(255, 0, 0),
+            Color.FromArgb(255, 127, 0),
+            Color.FromArgb(255, 255, 0),
+            Color.FromArgb(127, 255, 0),
+            Color.FromArgb(0, 255, 0),
+            Color.FromArgb(0, 255, 127),
+            Color.FromArgb(0, 255, 255),
+            Color.FromArgb(0, 127, 255),
+            Color.FromArgb(0, 0, 255),
+            Color.FromArgb(127, 0, 255),
+            Color.FromArgb(255, 0, 255),
+            Color.FromArgb(255, 0, 127),
+            Color.FromArgb(127, 127, 127)
+        };
+
+        private const int PaletteShades = 11;
+        private const int RecentColorsMax = 12;
+        private const int GrayColumnGapBase = 5;
+        private static readonly Size BaseClientSize = new Size(292, 218);
         private readonly Dictionary<int, Font> _labelFontsByDpi = new Dictionary<int, Font>();
         private readonly Dictionary<int, Font> _inputFontsByDpi = new Dictionary<int, Font>();
 
@@ -46,12 +70,15 @@ namespace Greenshot.Editor.Forms
         {
             SuspendLayout();
             InitializeComponent();
-            RebuildPaletteForDpi(DeviceDpi);
-            DpiChanged += (_, args) => RebuildPaletteForDpi(args.DeviceDpiNew);
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer, true);
+            DoubleBuffered = true;
+            DpiChanged += (_, args) => EnsurePaletteForDpi(args.DeviceDpiNew);
             ResumeLayout(true);
-            UpdateRecentColorsButtonRow();
+            EnsurePaletteForDpi(DeviceDpi);
             Disposed += (_, _) =>
             {
+                _paletteBitmap?.Dispose();
+                _paletteBitmap = null;
                 foreach (var font in _labelFontsByDpi.Values)
                 {
                     font.Dispose();
@@ -65,10 +92,30 @@ namespace Greenshot.Editor.Forms
             };
         }
 
-        private readonly List<Button> _colorButtons = new List<Button>();
         private readonly List<Button> _recentColorButtons = new List<Button>();
         private readonly ToolTip _toolTip = new ToolTip();
         private bool _updateInProgress;
+        private readonly Stopwatch _openStopwatch = new Stopwatch();
+        private bool _awaitingFirstShownLog;
+        private bool _awaitingFirstPaintLog;
+        private int _lastPaletteDpi = -1;
+        private Bitmap _paletteBitmap;
+        private Rectangle _paletteBounds = Rectangle.Empty;
+        private int _paletteCellSize;
+
+        private void EnsurePaletteForDpi(int dpi)
+        {
+            if (dpi <= 0)
+            {
+                dpi = 96;
+            }
+            if (_lastPaletteDpi == dpi)
+            {
+                return;
+            }
+            RebuildPaletteForDpi(dpi);
+            _lastPaletteDpi = dpi;
+        }
 
         private void ApplyTypographyForDpi(int dpi)
         {
@@ -105,20 +152,13 @@ namespace Greenshot.Editor.Forms
 
         private void RebuildPaletteForDpi(int dpi)
         {
-            ApplyTypographyForDpi(dpi);
-            foreach (var button in _colorButtons)
+            var rebuildStopwatch = Stopwatch.StartNew();
+            if (dpi <= 0)
             {
-                Controls.Remove(button);
-                button.Dispose();
+                dpi = 96;
             }
-            _colorButtons.Clear();
 
-            foreach (var button in _recentColorButtons)
-            {
-                Controls.Remove(button);
-                button.Dispose();
-            }
-            _recentColorButtons.Clear();
+            ApplyTypographyForDpi(dpi);
 
             var margin = DpiCalculator.ScaleWithDpi(5, dpi);
             var targetButtonSize = DpiCalculator.ScaleWithDpi(15, dpi);
@@ -126,10 +166,44 @@ namespace Greenshot.Editor.Forms
             var maxButtonSizeByHeight = (labelRecentColors.Top - margin - margin) / 11;
             var buttonSize = Math.Max(10, Math.Min(targetButtonSize, Math.Min(maxButtonSizeByWidth, maxButtonSizeByHeight)));
             var paletteBottom = margin + (11 * buttonSize);
+            var grayColumnGap = DpiCalculator.ScaleWithDpi(GrayColumnGapBase, dpi);
+            var labelRecentHeight = TextRenderer.MeasureText(labelRecentColors.Text ?? string.Empty, labelRecentColors.Font).Height;
+            var recentRowTop = paletteBottom + margin + labelRecentHeight + DpiCalculator.ScaleWithDpi(3, dpi);
+            _paletteCellSize = buttonSize;
+            _paletteBounds = new Rectangle(margin, margin, (BasePaletteColumnColors.Length * buttonSize) + grayColumnGap, PaletteShades * buttonSize);
+            RenderPaletteBitmap(_paletteBounds.Size, buttonSize, grayColumnGap);
 
-            CreateColorPalette(margin, margin, buttonSize, buttonSize);
-            CreateLastUsedColorButtonRow(margin, paletteBottom + margin, buttonSize, buttonSize);
-            labelRecentColors.Location = new Point(margin - 2, paletteBottom + 2);
+            if (_recentColorButtons.Count == 0)
+            {
+                CreateLastUsedColorButtonRow(margin, recentRowTop, buttonSize, buttonSize);
+            }
+            else
+            {
+                LayoutRecentColorButtonRow(margin, recentRowTop, buttonSize, buttonSize);
+            }
+
+            labelRecentColors.Location = new Point(margin - 2, paletteBottom + margin);
+            UpdateRecentColorsButtonRow();
+            rebuildStopwatch.Stop();
+            Log.Debug(
+                $"ColorDialog.RebuildPaletteForDpi dpi={dpi}, paletteCells={BasePaletteColumnColors.Length * PaletteShades}, recentButtons={_recentColorButtons.Count}, elapsedMs={rebuildStopwatch.ElapsedMilliseconds}");
+        }
+
+        private void LayoutRecentColorButtonRow(int x, int y, int w, int h)
+        {
+            for (var i = 0; i < _recentColorButtons.Count; i++)
+            {
+                LayoutButton(_recentColorButtons[i], x + (i * w), y, w, h);
+            }
+        }
+
+        private static void LayoutButton(Control control, int x, int y, int w, int h)
+        {
+            control.Location = new Point(x, y);
+            if (control.Width != w || control.Height != h)
+            {
+                control.Size = new Size(w, h);
+            }
         }
 
         public Color Color
@@ -138,82 +212,110 @@ namespace Greenshot.Editor.Forms
             set { PreviewColor(value, this); }
         }
 
-        private void CreateColorPalette(int x, int y, int w, int h)
+        private void RenderPaletteBitmap(Size paletteSize, int buttonSize, int grayColumnGap)
         {
-            CreateColorButtonColumn(255, 0, 0, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255, 255 / 2, 0, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255, 255, 0, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255 / 2, 255, 0, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(0, 255, 0, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(0, 255, 255 / 2, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(0, 255, 255, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(0, 255 / 2, 255, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(0, 0, 255, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255 / 2, 0, 255, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255, 0, 255, x, y, w, h, 11);
-            x += w;
-            CreateColorButtonColumn(255, 0, 255 / 2, x, y, w, h, 11);
-            x += w + 5;
-            CreateColorButtonColumn(255 / 2, 255 / 2, 255 / 2, x, y, w, h, 11);
-
-            Controls.AddRange(_colorButtons.ToArray());
-        }
-
-        private void CreateColorButtonColumn(int red, int green, int blue, int x, int y, int w, int h, int shades)
-        {
-            int shadedColorsNum = (shades - 1) / 2;
-            for (int i = 0; i <= shadedColorsNum; i++)
+            _paletteBitmap?.Dispose();
+            _paletteBitmap = new Bitmap(Math.Max(1, paletteSize.Width), Math.Max(1, paletteSize.Height));
+            using (var graphics = Graphics.FromImage(_paletteBitmap))
             {
-                _colorButtons.Add(CreateColorButton(red * i / shadedColorsNum, green * i / shadedColorsNum, blue * i / shadedColorsNum, x, y + i * h, w, h));
-                if (i > 0)
-                    _colorButtons.Add(CreateColorButton(red + (255 - red) * i / shadedColorsNum, green + (255 - green) * i / shadedColorsNum,
-                        blue + (255 - blue) * i / shadedColorsNum, x, y + (i + shadedColorsNum) * h, w, h));
+                graphics.Clear(BackColor);
+                for (var column = 0; column < BasePaletteColumnColors.Length; column++)
+                {
+                    var x = PaletteColumnToX(column, buttonSize, grayColumnGap);
+                    for (var row = 0; row < PaletteShades; row++)
+                    {
+                        using (var brush = new SolidBrush(GetPaletteColor(column, row)))
+                        {
+                            graphics.FillRectangle(brush, x, row * buttonSize, buttonSize, buttonSize);
+                        }
+                    }
+                }
             }
+            Invalidate(_paletteBounds);
         }
 
-        private Button CreateColorButton(int red, int green, int blue, int x, int y, int w, int h)
+        private static int PaletteColumnToX(int column, int buttonSize, int grayColumnGap)
         {
-            return CreateColorButton(Color.FromArgb(255, red, green, blue), x, y, w, h);
-        }
-
-        private Button CreateColorButton(Color color, int x, int y, int w, int h)
-        {
-            Button b = new GreenshotDoubleClickButton
+            var x = column * buttonSize;
+            if (column == BasePaletteColumnColors.Length - 1)
             {
-                BackColor = color,
-                FlatStyle = FlatStyle.Flat,
-                Location = new Point(x, y),
-                Size = new Size(w, h),
-                TabStop = false
-            };
-            b.FlatAppearance.BorderSize = 0;
-            b.Click += ColorButtonClick;
-            b.DoubleClick += ColorButtonDoubleClick;
-            SetButtonTooltip(b, color);
-            return b;
+                x += grayColumnGap;
+            }
+            return x;
         }
 
-        private void ColorButtonDoubleClick(object sender, EventArgs e)
+        private Color GetPaletteColor(int column, int row)
         {
-            ColorButtonClick(sender, e);
-            BtnApplyClick(sender, e);
+            var shadedColorsNum = (PaletteShades - 1) / 2;
+            var baseColor = BasePaletteColumnColors[Math.Max(0, Math.Min(BasePaletteColumnColors.Length - 1, column))];
+            if (row <= shadedColorsNum)
+            {
+                return ScaleColor(baseColor, row / (float)shadedColorsNum);
+            }
+            var lightenFactor = (row - shadedColorsNum) / (float)shadedColorsNum;
+            return LightenColor(baseColor, lightenFactor);
+        }
+
+        private static Color ScaleColor(Color color, float factor) =>
+            Color.FromArgb(255, (int)(color.R * factor), (int)(color.G * factor), (int)(color.B * factor));
+
+        private static Color LightenColor(Color color, float factor) =>
+            Color.FromArgb(
+                255,
+                color.R + (int)((255 - color.R) * factor),
+                color.G + (int)((255 - color.G) * factor),
+                color.B + (int)((255 - color.B) * factor));
+
+        private bool TryGetPaletteColorFromPoint(Point point, out Color color)
+        {
+            color = Color.Empty;
+            if (_paletteBounds == Rectangle.Empty || !_paletteBounds.Contains(point) || _paletteCellSize <= 0)
+            {
+                return false;
+            }
+
+            var localX = point.X - _paletteBounds.Left;
+            var localY = point.Y - _paletteBounds.Top;
+            var grayGap = _paletteBounds.Width - (BasePaletteColumnColors.Length * _paletteCellSize);
+            var grayStartX = (BasePaletteColumnColors.Length - 1) * _paletteCellSize + grayGap;
+
+            int column;
+            if (localX >= grayStartX)
+            {
+                column = BasePaletteColumnColors.Length - 1;
+                localX -= grayGap;
+            }
+            else
+            {
+                column = localX / _paletteCellSize;
+            }
+
+            var row = localY / _paletteCellSize;
+            if (column < 0 || column >= BasePaletteColumnColors.Length || row < 0 || row >= PaletteShades)
+            {
+                return false;
+            }
+
+            color = GetPaletteColor(column, row);
+            return true;
         }
 
         private void CreateLastUsedColorButtonRow(int x, int y, int w, int h)
         {
             for (int i = 0; i < 12; i++)
             {
-                Button b = CreateColorButton(Color.Transparent, x, y, w, h);
+                Button b = new GreenshotDoubleClickButton
+                {
+                    BackColor = Color.Transparent,
+                    FlatStyle = FlatStyle.Flat,
+                    Location = new Point(x, y),
+                    Size = new Size(w, h),
+                    TabStop = false,
+                    Enabled = false
+                };
+                b.FlatAppearance.BorderSize = 0;
+                b.Click += ColorButtonClick;
+                b.DoubleClick += ColorButtonDoubleClick;
                 b.Enabled = false;
                 _recentColorButtons.Add(b);
                 x += w;
@@ -224,11 +326,22 @@ namespace Greenshot.Editor.Forms
 
         private void UpdateRecentColorsButtonRow()
         {
-            for (int i = 0; i < EditorConfig.RecentColors.Count && i < 12; i++)
+            if (_recentColorButtons.Count == 0)
+            {
+                return;
+            }
+
+            for (int i = 0; i < EditorConfig.RecentColors.Count && i < RecentColorsMax; i++)
             {
                 _recentColorButtons[i].BackColor = EditorConfig.RecentColors[i];
                 _recentColorButtons[i].Enabled = true;
                 SetButtonTooltip(_recentColorButtons[i], EditorConfig.RecentColors[i]);
+            }
+
+            for (int i = EditorConfig.RecentColors.Count; i < _recentColorButtons.Count; i++)
+            {
+                _recentColorButtons[i].BackColor = Color.Transparent;
+                _recentColorButtons[i].Enabled = false;
             }
         }
 
@@ -327,6 +440,12 @@ namespace Greenshot.Editor.Forms
             PreviewColor(b.BackColor, b);
         }
 
+        private void ColorButtonDoubleClick(object sender, EventArgs e)
+        {
+            ColorButtonClick(sender, e);
+            BtnApplyClick(sender, e);
+        }
+
         private void SetButtonTooltip(Button colorButton, Color color)
         {
             _toolTip.SetToolTip(colorButton, ColorTranslator.ToHtml(color) + " | R:" + color.R + ", G:" + color.G + ", B:" + color.B);
@@ -366,24 +485,175 @@ namespace Greenshot.Editor.Forms
 
         public new DialogResult ShowDialog(IWin32Window owner)
         {
+            var showStopwatch = Stopwatch.StartNew();
+            _openStopwatch.Restart();
+            _awaitingFirstShownLog = true;
+            _awaitingFirstPaintLog = true;
             var mouse = Cursor.Position;
             var targetDpi = NativeDpiMethods.GetDpi(mouse);
+            if (targetDpi <= 0)
+            {
+                targetDpi = 96;
+            }
+
+            // Keep dialog sizing on the framework autoscale path.
+            AutoScaleMode = AutoScaleMode.Dpi;
+            Font = GetFontForDpi(_inputFontsByDpi, 96, 8.25f);
+            ClientSize = BaseClientSize;
+            var screen = Screen.FromPoint(mouse);
+            var workingArea = screen.WorkingArea;
+            StartPosition = FormStartPosition.Manual;
+            Location = new Point(
+                Math.Max(workingArea.Left, Math.Min(mouse.X - Width / 2, workingArea.Right - Width)),
+                Math.Max(workingArea.Top, Math.Min(mouse.Y - Height / 2, workingArea.Bottom - Height)));
+            _ = Handle;
             if (DeviceDpi > 0 && DeviceDpi != targetDpi)
             {
                 var scaleFactor = targetDpi / (float)DeviceDpi;
                 Scale(new SizeF(scaleFactor, scaleFactor));
             }
-            RebuildPaletteForDpi(targetDpi);
-            var screen = Screen.FromPoint(mouse);
-            var workingArea = screen.WorkingArea;
+            var dialogDpi = targetDpi;
+            var baseClientSize = DpiCalculator.ScaleWithDpi(BaseClientSize, dialogDpi);
+            ClientSize = baseClientSize;
+            SuspendLayout();
+            EnsurePaletteForDpi(dialogDpi);
 
-            int x = Math.Max(workingArea.Left, Math.Min(mouse.X - Width / 2, workingArea.Right - Width));
-            int y = Math.Max(workingArea.Top, Math.Min(mouse.Y - Height / 2, workingArea.Bottom - Height));
+            // Two-pass sizing:
+            // 1) layout once, measure required bounds
+            // 2) apply size, layout again, then expand/shrink if still off by a small amount.
+            var contentPadding = DpiCalculator.ScaleWithDpi(12, dialogDpi);
+            var scaleUpSafety = (DeviceDpi > 0 && dialogDpi > DeviceDpi)
+                ? DpiCalculator.ScaleWithDpi(10, dialogDpi)
+                : 0;
 
-            StartPosition = FormStartPosition.Manual;
-            Location = new Point(x, y);
+            Size MeasureRequiredClientSize()
+            {
+                var requiredWidth = 0;
+                var requiredHeight = 0;
+                foreach (Control control in Controls)
+                {
+                    if (!control.Visible)
+                    {
+                        continue;
+                    }
+
+                    requiredWidth = Math.Max(requiredWidth, control.Right);
+                    requiredHeight = Math.Max(requiredHeight, control.Bottom);
+                }
+                requiredWidth = Math.Max(requiredWidth, _paletteBounds.Right);
+                requiredHeight = Math.Max(requiredHeight, _paletteBounds.Bottom);
+                requiredHeight += scaleUpSafety;
+
+                return new Size(
+                    Math.Max(baseClientSize.Width, requiredWidth + contentPadding),
+                    Math.Max(baseClientSize.Height, requiredHeight + contentPadding));
+            }
+
+            ResumeLayout(false);
+            PerformLayout();
+            var targetClientSize = MeasureRequiredClientSize();
+
+            SuspendLayout();
+            ClientSize = targetClientSize;
+            ResumeLayout(false);
+            PerformLayout();
+
+            // Re-measure after layout: expand if still clipped; shrink slightly on downscale if we overshot.
+            var measuredAfter = MeasureRequiredClientSize();
+            var finalSize = ClientSize;
+            if (measuredAfter.Width > ClientSize.Width || measuredAfter.Height > ClientSize.Height)
+            {
+                SuspendLayout();
+                ClientSize = new Size(Math.Max(ClientSize.Width, measuredAfter.Width), Math.Max(ClientSize.Height, measuredAfter.Height));
+                ResumeLayout(false);
+                PerformLayout();
+                finalSize = ClientSize;
+            }
+            else
+            {
+                var allowShrink = DeviceDpi > 0 && dialogDpi < DeviceDpi;
+                if (allowShrink)
+                {
+                    SuspendLayout();
+                    ClientSize = new Size(
+                        Math.Max(baseClientSize.Width, measuredAfter.Width),
+                        Math.Max(baseClientSize.Height, measuredAfter.Height));
+                    ResumeLayout(false);
+                    PerformLayout();
+                    finalSize = ClientSize;
+                }
+            }
+
+            Log.Debug(
+                $"ColorDialog.SizePass baseClient={baseClientSize}, pass1Target={targetClientSize}, pass2Measured={measuredAfter}, finalClient={finalSize}, " +
+                $"deltaW={finalSize.Width - measuredAfter.Width}, deltaH={finalSize.Height - measuredAfter.Height}, " +
+                $"targetDpi={targetDpi}, deviceDpi={DeviceDpi}, layoutDpi={dialogDpi}");
+
+            // Empirical slack: in mixed-DPI transitions WinForms can still adjust the client area
+            // after our measurement pass (seen as "slightly too small"). Add a small extra height
+            // only when scaling up to avoid clipping, without worsening the downscale case.
+            if (DeviceDpi > 0 && dialogDpi > DeviceDpi)
+            {
+                var visualSlackH = DpiCalculator.ScaleWithDpi(16, dialogDpi);
+                var visualSlackW = DpiCalculator.ScaleWithDpi(10, dialogDpi);
+                ClientSize = new Size(ClientSize.Width + visualSlackW, ClientSize.Height + visualSlackH);
+            }
+            Location = new Point(
+                Math.Max(workingArea.Left, Math.Min(mouse.X - Width / 2, workingArea.Right - Width)),
+                Math.Max(workingArea.Top, Math.Min(mouse.Y - Height / 2, workingArea.Bottom - Height)));
+
+            Log.Debug($"ColorDialog.FinalClientSize client={ClientSize}, targetDpi={targetDpi}, deviceDpi={DeviceDpi}, layoutDpi={dialogDpi}");
+
+            Log.Debug($"ColorDialog.ShowDialog targetDpi={targetDpi}, deviceDpi={DeviceDpi}, layoutDpi={dialogDpi}, size={Size}, client={ClientSize}, location={Location}");
+            showStopwatch.Stop();
+            Log.Debug($"ColorDialog.ShowDialog setup elapsedMs={showStopwatch.ElapsedMilliseconds}");
 
             return base.ShowDialog(owner);
         }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            if (_awaitingFirstShownLog)
+            {
+                _awaitingFirstShownLog = false;
+                Log.Debug($"ColorDialog.OnShown elapsedMs={_openStopwatch.ElapsedMilliseconds}");
+            }
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            if (_paletteBitmap != null && _paletteBounds != Rectangle.Empty)
+            {
+                e.Graphics.DrawImageUnscaled(_paletteBitmap, _paletteBounds.Location);
+            }
+            if (_awaitingFirstPaintLog)
+            {
+                _awaitingFirstPaintLog = false;
+                _openStopwatch.Stop();
+                Log.Debug($"ColorDialog.FirstPaint elapsedMs={_openStopwatch.ElapsedMilliseconds}");
+            }
+        }
+
+        protected override void OnMouseClick(MouseEventArgs e)
+        {
+            base.OnMouseClick(e);
+            if (TryGetPaletteColorFromPoint(e.Location, out var color))
+            {
+                PreviewColor(color, this);
+            }
+        }
+
+        protected override void OnMouseDoubleClick(MouseEventArgs e)
+        {
+            base.OnMouseDoubleClick(e);
+            if (TryGetPaletteColorFromPoint(e.Location, out var color))
+            {
+                PreviewColor(color, this);
+                BtnApplyClick(this, EventArgs.Empty);
+            }
+        }
+
     }
 }

--- a/src/Greenshot.Editor/Forms/ColorDialog.cs
+++ b/src/Greenshot.Editor/Forms/ColorDialog.cs
@@ -25,6 +25,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Threading;
 using System.Windows.Forms;
+using Dapplo.Windows.Dpi;
 using Greenshot.Base.Controls;
 using Greenshot.Base.IniFile;
 using Greenshot.Editor.Configuration;
@@ -44,10 +45,9 @@ namespace Greenshot.Editor.Forms
         {
             SuspendLayout();
             InitializeComponent();
-            SuspendLayout();
-            CreateColorPalette(5, 5, 15, 15);
-            CreateLastUsedColorButtonRow(5, 190, 15, 15);
-            ResumeLayout();
+            RebuildPaletteForDpi(DeviceDpi);
+            DpiChanged += (_, args) => RebuildPaletteForDpi(args.DeviceDpiNew);
+            ResumeLayout(true);
             UpdateRecentColorsButtonRow();
             _instance = this;
         }
@@ -58,6 +58,57 @@ namespace Greenshot.Editor.Forms
         private readonly List<Button> _recentColorButtons = new List<Button>();
         private readonly ToolTip _toolTip = new ToolTip();
         private bool _updateInProgress;
+
+        private void ApplyTypographyForDpi(int dpi)
+        {
+            var labelFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(10f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            var inputFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+
+            labelHtmlColor.Font = labelFont;
+            labelRed.Font = labelFont;
+            labelGreen.Font = labelFont;
+            labelBlue.Font = labelFont;
+            labelAlpha.Font = labelFont;
+            labelRecentColors.Font = inputFont;
+
+            textBoxHtmlColor.Font = inputFont;
+            textBoxRed.Font = inputFont;
+            textBoxGreen.Font = inputFont;
+            textBoxBlue.Font = inputFont;
+            textBoxAlpha.Font = inputFont;
+
+            btnTransparent.Font = inputFont;
+            btnApply.Font = inputFont;
+        }
+
+        private void RebuildPaletteForDpi(int dpi)
+        {
+            ApplyTypographyForDpi(dpi);
+            foreach (var button in _colorButtons)
+            {
+                Controls.Remove(button);
+                button.Dispose();
+            }
+            _colorButtons.Clear();
+
+            foreach (var button in _recentColorButtons)
+            {
+                Controls.Remove(button);
+                button.Dispose();
+            }
+            _recentColorButtons.Clear();
+
+            var margin = DpiCalculator.ScaleWithDpi(5, dpi);
+            var targetButtonSize = DpiCalculator.ScaleWithDpi(15, dpi);
+            var maxButtonSizeByWidth = (btnTransparent.Left - margin - margin) / 13;
+            var maxButtonSizeByHeight = (labelRecentColors.Top - margin - margin) / 11;
+            var buttonSize = Math.Max(10, Math.Min(targetButtonSize, Math.Min(maxButtonSizeByWidth, maxButtonSizeByHeight)));
+            var paletteBottom = margin + (11 * buttonSize);
+
+            CreateColorPalette(margin, margin, buttonSize, buttonSize);
+            CreateLastUsedColorButtonRow(margin, paletteBottom + margin, buttonSize, buttonSize);
+            labelRecentColors.Location = new Point(margin - 2, paletteBottom + 2);
+        }
 
         public Color Color
         {
@@ -294,6 +345,13 @@ namespace Greenshot.Editor.Forms
         public new DialogResult ShowDialog(IWin32Window owner)
         {
             var mouse = Cursor.Position;
+            var targetDpi = NativeDpiMethods.GetDpi(mouse);
+            if (DeviceDpi > 0 && DeviceDpi != targetDpi)
+            {
+                var scaleFactor = targetDpi / (float)DeviceDpi;
+                Scale(new SizeF(scaleFactor, scaleFactor));
+            }
+            RebuildPaletteForDpi(targetDpi);
             var screen = Screen.FromPoint(mouse);
             var workingArea = screen.WorkingArea;
 

--- a/src/Greenshot.Editor/Forms/ColorDialog.cs
+++ b/src/Greenshot.Editor/Forms/ColorDialog.cs
@@ -39,7 +39,8 @@ namespace Greenshot.Editor.Forms
     public partial class ColorDialog : EditorForm
     {
         private static readonly EditorConfiguration EditorConfig = IniConfig.GetIniSection<EditorConfiguration>();
-        private static ColorDialog _instance;
+        private readonly Dictionary<int, Font> _labelFontsByDpi = new Dictionary<int, Font>();
+        private readonly Dictionary<int, Font> _inputFontsByDpi = new Dictionary<int, Font>();
 
         public ColorDialog()
         {
@@ -49,10 +50,20 @@ namespace Greenshot.Editor.Forms
             DpiChanged += (_, args) => RebuildPaletteForDpi(args.DeviceDpiNew);
             ResumeLayout(true);
             UpdateRecentColorsButtonRow();
-            _instance = this;
+            Disposed += (_, _) =>
+            {
+                foreach (var font in _labelFontsByDpi.Values)
+                {
+                    font.Dispose();
+                }
+                _labelFontsByDpi.Clear();
+                foreach (var font in _inputFontsByDpi.Values)
+                {
+                    font.Dispose();
+                }
+                _inputFontsByDpi.Clear();
+            };
         }
-
-        public static ColorDialog GetInstance() => _instance;
 
         private readonly List<Button> _colorButtons = new List<Button>();
         private readonly List<Button> _recentColorButtons = new List<Button>();
@@ -61,8 +72,8 @@ namespace Greenshot.Editor.Forms
 
         private void ApplyTypographyForDpi(int dpi)
         {
-            var labelFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(10f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
-            var inputFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            var labelFont = GetFontForDpi(_labelFontsByDpi, dpi, 10f);
+            var inputFont = GetFontForDpi(_inputFontsByDpi, dpi, 11f);
 
             labelHtmlColor.Font = labelFont;
             labelRed.Font = labelFont;
@@ -79,6 +90,17 @@ namespace Greenshot.Editor.Forms
 
             btnTransparent.Font = inputFont;
             btnApply.Font = inputFont;
+        }
+
+        private Font GetFontForDpi(Dictionary<int, Font> cache, int dpi, float baseSize)
+        {
+            if (!cache.TryGetValue(dpi, out var font))
+            {
+                font = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(baseSize, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+                cache[dpi] = font;
+            }
+
+            return font;
         }
 
         private void RebuildPaletteForDpi(int dpi)

--- a/src/Greenshot.Editor/Forms/ColorPickerToolStripButton.cs
+++ b/src/Greenshot.Editor/Forms/ColorPickerToolStripButton.cs
@@ -35,12 +35,10 @@ namespace Greenshot.Editor.Forms
         private Color _color;
         public NativePoint Offset = new NativePoint(0, 0);
         public event ColorPickerEventHandler ColorPicked;
-        private readonly ColorDialog _cd;
 
 
         public ColorPickerToolStripButton()
         {
-            _cd = ColorDialog.GetInstance();
             Click += ToolStripButton1Click;
         }
 
@@ -79,8 +77,12 @@ namespace Greenshot.Editor.Forms
 
         void ToolStripButton1Click(object sender, EventArgs e)
         {
-            _cd.ShowDialog(Owner);
-            Color = _cd.Color;
+            using var colorDialog = new ColorDialog
+            {
+                Color = Color
+            };
+            colorDialog.ShowDialog(Owner);
+            Color = colorDialog.Color;
             ColorPicked?.Invoke(this, new ColorPickerEventArgs(Color));
         }
     }

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.Designer.cs
@@ -327,7 +327,7 @@ namespace Greenshot.Editor.Forms
 			// toolsToolStrip
 			// 
 			this.toolsToolStrip.ClickThrough = true;
-			this.toolsToolStrip.ImageScalingSize = coreConfiguration.IconSize;
+			this.toolsToolStrip.ImageScalingSize = coreConfiguration.EditorIconSize;
 			this.toolsToolStrip.Dock = System.Windows.Forms.DockStyle.None;
 			this.toolsToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
 			this.toolsToolStrip.Renderer = new CustomToolStripProfessionalRenderer();
@@ -583,7 +583,7 @@ namespace Greenshot.Editor.Forms
 			// menuStrip1
 			// 
 			this.menuStrip1.ClickThrough = true;
-			this.menuStrip1.ImageScalingSize = coreConfiguration.IconSize;
+			this.menuStrip1.ImageScalingSize = coreConfiguration.EditorIconSize;
 			this.menuStrip1.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.menuStrip1.Stretch = true;
 			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -907,7 +907,7 @@ namespace Greenshot.Editor.Forms
 			// destinationsToolStrip
 			// 
 			this.destinationsToolStrip.ClickThrough = true;
-			this.destinationsToolStrip.ImageScalingSize = coreConfiguration.IconSize;
+			this.destinationsToolStrip.ImageScalingSize = coreConfiguration.EditorIconSize;
 			this.destinationsToolStrip.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.destinationsToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
 			this.destinationsToolStrip.Name = "toolStrip1";
@@ -1062,10 +1062,10 @@ namespace Greenshot.Editor.Forms
 			// propertiesToolStrip
 			// 
 			this.propertiesToolStrip.ClickThrough = true;
-			this.propertiesToolStrip.ImageScalingSize = coreConfiguration.IconSize;
+			this.propertiesToolStrip.ImageScalingSize = coreConfiguration.EditorIconSize;
 			this.propertiesToolStrip.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.propertiesToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-			this.propertiesToolStrip.MinimumSize = new System.Drawing.Size(150, coreConfiguration.IconSize.Height + 10);
+			this.propertiesToolStrip.MinimumSize = new System.Drawing.Size(150, coreConfiguration.EditorIconSize.Height + 10);
 			this.propertiesToolStrip.Name = "propertiesToolStrip";
 			this.propertiesToolStrip.Stretch = true;
 			this.propertiesToolStrip.TabIndex = 2;
@@ -1304,7 +1304,7 @@ namespace Greenshot.Editor.Forms
 			this.fontFamilyComboBox.Name = "fontFamilyComboBox";
 			this.fontFamilyComboBox.Size = new System.Drawing.Size(200, 20);
 			this.fontFamilyComboBox.Text = "Aharoni";
-			this.fontFamilyComboBox.Padding = new System.Windows.Forms.Padding(2,0,0,2);
+			this.fontFamilyComboBox.Padding = new System.Windows.Forms.Padding(0);
 			this.fontFamilyComboBox.GotFocus += new System.EventHandler(this.ToolBarFocusableElementGotFocus);
 			this.fontFamilyComboBox.LostFocus += new System.EventHandler(this.ToolBarFocusableElementLostFocus);
             this.fontFamilyComboBox.PropertyChanged += FontPropertyChanged;

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -130,14 +130,54 @@ namespace Greenshot.Editor.Forms
         /// <param name="newDpi"></param>
         protected override void DpiChangedHandler(int oldDpi, int newDpi)
         {
-            var newSize = DpiCalculator.ScaleWithDpi(coreConfiguration.IconSize, newDpi);
+            ApplyDpiLayout(newDpi);
+            _surface?.AdjustToDpi(newDpi);
+            UpdateUi();
+        }
+
+        private void ApplyDpiLayout(int dpi)
+        {
+            if (dpi <= 0)
+            {
+                dpi = 96;
+            }
+
+            var newSize = DpiCalculator.ScaleWithDpi(coreConfiguration.EditorIconSize, dpi);
             toolsToolStrip.ImageScalingSize = newSize;
             menuStrip1.ImageScalingSize = newSize;
             destinationsToolStrip.ImageScalingSize = newSize;
             propertiesToolStrip.ImageScalingSize = newSize;
             propertiesToolStrip.MinimumSize = new Size(150, newSize.Height + 10);
-            _surface?.AdjustToDpi(newDpi);
-            UpdateUi();
+            var controlHeight = DpiCalculator.ScaleWithDpi(22, dpi);
+            fontFamilyComboBox.AutoSize = false;
+            fontFamilyComboBox.Size = new Size(DpiCalculator.ScaleWithDpi(200, dpi), controlHeight);
+            fontFamilyComboBox.ComboBox.ItemHeight = Math.Max(DpiCalculator.ScaleWithDpi(16, dpi), 16);
+            var fontPickerFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(9.5f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            fontFamilyComboBox.Font = fontPickerFont;
+            fontFamilyComboBox.ComboBox.Font = fontPickerFont;
+            var numericPickerFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            fontSizeUpDown.AutoSize = false;
+            fontSizeUpDown.Size = new Size(DpiCalculator.ScaleWithDpi(60, dpi), controlHeight);
+            fontSizeUpDown.Font = numericPickerFont;
+            lineThicknessUpDown.AutoSize = false;
+            lineThicknessUpDown.Size = new Size(DpiCalculator.ScaleWithDpi(60, dpi), controlHeight);
+            lineThicknessUpDown.Font = numericPickerFont;
+            ApplyZoomMenuDpi(dpi);
+        }
+
+        private void ApplyZoomMenuDpi(int dpi)
+        {
+            if (dpi <= 0)
+            {
+                dpi = 96;
+            }
+
+            var zoomMenuFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            zoomMenuStrip.Font = zoomMenuFont;
+            foreach (ToolStripItem item in zoomMenuStrip.Items)
+            {
+                item.Font = zoomMenuFont;
+            }
         }
 
         public ImageEditorForm()
@@ -162,6 +202,8 @@ namespace Greenshot.Editor.Forms
             //
             ManualLanguageApply = true;
             InitializeComponent();
+            zoomMainMenuItem.DropDownOpening += (s, e) => ApplyZoomMenuDpi(NativeDpiMethods.GetDpi(Cursor.Position));
+            zoomStatusDropDownBtn.DropDownOpening += (s, e) => ApplyZoomMenuDpi(NativeDpiMethods.GetDpi(Cursor.Position));
             // Add the destinations after the form is loaded, this is needed for the dynamic destinations which need the handle of the form
             Load += (s, eventArgs) => AddDestinations();
 
@@ -184,6 +226,7 @@ namespace Greenshot.Editor.Forms
             Surface = surface;
             // Initial "saved" flag for asking if the image needs to be save
             _surface.Modified = !outputMade;
+            ApplyDpiLayout(NativeDpiMethods.GetDpi(Handle));
 
             // Note: SetSurface (called via Surface = surface above) already registered this
             // editor in EditorList. Do NOT add again here — double-registration causes

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -88,6 +88,9 @@ namespace Greenshot.Editor.Forms
 
         private bool _originalBoldCheckState;
         private bool _originalItalicCheckState;
+        private readonly Dictionary<int, Font> _fontPickerFontsByDpi = new Dictionary<int, Font>();
+        private readonly Dictionary<int, Font> _numericPickerFontsByDpi = new Dictionary<int, Font>();
+        private readonly Dictionary<int, Font> _zoomMenuFontsByDpi = new Dictionary<int, Font>();
 
         // whether part of the editor controls are disabled depending on selected item(s)
         private bool _controlsDisabledDueToConfirmable;
@@ -152,10 +155,10 @@ namespace Greenshot.Editor.Forms
             fontFamilyComboBox.AutoSize = false;
             fontFamilyComboBox.Size = new Size(DpiCalculator.ScaleWithDpi(200, dpi), controlHeight);
             fontFamilyComboBox.ComboBox.ItemHeight = Math.Max(DpiCalculator.ScaleWithDpi(16, dpi), 16);
-            var fontPickerFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(9.5f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            var fontPickerFont = GetCachedFont(_fontPickerFontsByDpi, dpi, 9.5f);
             fontFamilyComboBox.Font = fontPickerFont;
             fontFamilyComboBox.ComboBox.Font = fontPickerFont;
-            var numericPickerFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            var numericPickerFont = GetCachedFont(_numericPickerFontsByDpi, dpi, 11f);
             fontSizeUpDown.AutoSize = false;
             fontSizeUpDown.Size = new Size(DpiCalculator.ScaleWithDpi(60, dpi), controlHeight);
             fontSizeUpDown.Font = numericPickerFont;
@@ -172,12 +175,23 @@ namespace Greenshot.Editor.Forms
                 dpi = 96;
             }
 
-            var zoomMenuFont = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(11f, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+            var zoomMenuFont = GetCachedFont(_zoomMenuFontsByDpi, dpi, 11f);
             zoomMenuStrip.Font = zoomMenuFont;
             foreach (ToolStripItem item in zoomMenuStrip.Items)
             {
                 item.Font = zoomMenuFont;
             }
+        }
+
+        private Font GetCachedFont(Dictionary<int, Font> cache, int dpi, float baseSize)
+        {
+            if (!cache.TryGetValue(dpi, out var font))
+            {
+                font = new Font(Font.FontFamily, DpiCalculator.ScaleWithDpi(baseSize, dpi), FontStyle.Regular, GraphicsUnit.Pixel);
+                cache[dpi] = font;
+            }
+
+            return font;
         }
 
         public ImageEditorForm()
@@ -204,6 +218,24 @@ namespace Greenshot.Editor.Forms
             InitializeComponent();
             zoomMainMenuItem.DropDownOpening += (s, e) => ApplyZoomMenuDpi(NativeDpiMethods.GetDpi(Cursor.Position));
             zoomStatusDropDownBtn.DropDownOpening += (s, e) => ApplyZoomMenuDpi(NativeDpiMethods.GetDpi(Cursor.Position));
+            FormClosed += (_, _) =>
+            {
+                foreach (var font in _fontPickerFontsByDpi.Values)
+                {
+                    font.Dispose();
+                }
+                _fontPickerFontsByDpi.Clear();
+                foreach (var font in _numericPickerFontsByDpi.Values)
+                {
+                    font.Dispose();
+                }
+                _numericPickerFontsByDpi.Clear();
+                foreach (var font in _zoomMenuFontsByDpi.Values)
+                {
+                    font.Dispose();
+                }
+                _zoomMenuFontsByDpi.Clear();
+            };
             // Add the destinations after the form is loaded, this is needed for the dynamic destinations which need the handle of the form
             Load += (s, eventArgs) => AddDestinations();
 
@@ -1991,7 +2023,7 @@ namespace Greenshot.Editor.Forms
 
         private void RemoveTransparencyToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var colorDialog = new ColorDialog
+            using var colorDialog = new ColorDialog
             {
                 Color = Color.White
             };

--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -2098,8 +2098,16 @@ namespace Greenshot.Editor.Forms
             newHeight = Math.Min(newHeight, maxWindowSize.Height);
 
             // Lower bound. Don't make it smaller than a fixed value.
-            int minimumFormWidth = 650;
-            int minimumFormHeight = 530;
+            // Use the window's current screen DPI (not only DeviceDpi) so runtime monitor scale
+            // transitions don't keep an outdated minimum size.
+            var windowCenter = new Point(Left + Width / 2, Top + Height / 2);
+            var dpi = NativeDpiMethods.GetDpi(windowCenter);
+            if (dpi <= 0)
+            {
+                dpi = DeviceDpi > 0 ? DeviceDpi : 96;
+            }
+            int minimumFormWidth = DpiCalculator.ScaleWithDpi(650, dpi);
+            int minimumFormHeight = DpiCalculator.ScaleWithDpi(530, dpi);
             newWidth = Math.Max(minimumFormWidth, newWidth);
             newHeight = Math.Max(minimumFormHeight, newHeight);
 

--- a/src/Greenshot.Editor/Forms/MovableShowColorForm.cs
+++ b/src/Greenshot.Editor/Forms/MovableShowColorForm.cs
@@ -24,6 +24,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using Dapplo.Windows.Common.Extensions;
 using Dapplo.Windows.Common.Structs;
+using Dapplo.Windows.Dpi;
 using Dapplo.Windows.Gdi32;
 using Dapplo.Windows.Gdi32.SafeHandles;
 using Dapplo.Windows.User32;
@@ -63,8 +64,9 @@ namespace Greenshot.Editor.Forms
             NativeSize cursorSize = Cursor.Current.Size;
             NativePoint hotspot = Cursor.Current.HotSpot;
 
+            var spacing = DpiCalculator.ScaleWithDpi(5, DeviceDpi);
             var zoomerLocation = new NativePoint(screenCoordinates.X, screenCoordinates.Y)
-                .Offset(cursorSize.Width + 5 - hotspot.X, cursorSize.Height + 5 - hotspot.Y);
+                .Offset(cursorSize.Width + spacing - hotspot.X, cursorSize.Height + spacing - hotspot.Y);
 
             foreach (var displayInfo in DisplayInfo.AllDisplayInfos)
             {
@@ -77,7 +79,7 @@ namespace Greenshot.Editor.Forms
                 }
                 else if (zoomerLocation.X + Width > screenRectangle.X + screenRectangle.Width)
                 {
-                    zoomerLocation = zoomerLocation.ChangeX(screenCoordinates.X - Width - 5 - hotspot.X);
+                    zoomerLocation = zoomerLocation.ChangeX(screenCoordinates.X - Width - spacing - hotspot.X);
                 }
 
                 if (zoomerLocation.Y < screenRectangle.Y)
@@ -86,7 +88,7 @@ namespace Greenshot.Editor.Forms
                 }
                 else if (zoomerLocation.Y + Height > screenRectangle.Y + screenRectangle.Height)
                 {
-                    zoomerLocation = zoomerLocation.ChangeY(screenCoordinates.Y - Height - 5 - hotspot.Y);
+                    zoomerLocation = zoomerLocation.ChangeY(screenCoordinates.Y - Height - spacing - hotspot.Y);
                 }
 
                 break;

--- a/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
@@ -146,7 +146,7 @@ public class ExternalCommandPlugin : IGreenshotPlugin
 
         _itemPlugInRoot = new ToolStripMenuItem();
         _itemPlugInRoot.Click += ConfigMenuClick;
-        OnIconSizeChanged(this, new PropertyChangedEventArgs("IconSize"));
+        OnIconSizeChanged(this, new PropertyChangedEventArgs(nameof(CoreConfig.MenuIconSize)));
         OnLanguageChanged(this, null);
 
         PluginUtils.AddToContextMenu(_itemPlugInRoot);
@@ -162,7 +162,7 @@ public class ExternalCommandPlugin : IGreenshotPlugin
     /// <param name="e"></param>
     private void OnIconSizeChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == "IconSize")
+        if (e.PropertyName == nameof(CoreConfig.MenuIconSize) || e.PropertyName == nameof(CoreConfig.IconSize))
         {
             try
             {

--- a/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
+++ b/src/Greenshot.Plugin.ExternalCommand/ExternalCommandPlugin.cs
@@ -162,7 +162,9 @@ public class ExternalCommandPlugin : IGreenshotPlugin
     /// <param name="e"></param>
     private void OnIconSizeChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(CoreConfig.MenuIconSize) || e.PropertyName == nameof(CoreConfig.IconSize))
+        if (e.PropertyName == nameof(CoreConfig.MenuIconSize) ||
+            e.PropertyName == nameof(CoreConfig.IconSize) ||
+            e.PropertyName == nameof(CoreConfig.EditorIconSize))
         {
             try
             {

--- a/src/Greenshot.Plugin.Jira/Forms/JiraForm.cs
+++ b/src/Greenshot.Plugin.Jira/Forms/JiraForm.cs
@@ -199,7 +199,7 @@ public partial class JiraForm : Form
                 jiraListView.Columns.Add(translation);
             }
 
-            var scaledIconSize = DpiCalculator.ScaleWithDpi(CoreConfig.IconSize, NativeDpiMethods.GetDpi(Handle));
+            var scaledIconSize = DpiCalculator.ScaleWithDpi(CoreConfig.MenuIconSize, NativeDpiMethods.GetDpi(Handle));
             var imageList = new ImageList
             {
                 ImageSize = scaledIconSize

--- a/src/Greenshot.Plugin.Jira/JiraConnector.cs
+++ b/src/Greenshot.Plugin.Jira/JiraConnector.cs
@@ -58,7 +58,9 @@ public sealed class JiraConnector : IDisposable
     {
         CoreConfig.PropertyChanged += (sender, args) =>
         {
-            if (args.PropertyName == nameof(CoreConfig.MenuIconSize) || args.PropertyName == nameof(CoreConfig.IconSize))
+            if (args.PropertyName == nameof(CoreConfig.MenuIconSize) ||
+                args.PropertyName == nameof(CoreConfig.IconSize) ||
+                args.PropertyName == nameof(CoreConfig.EditorIconSize))
             {
                 var jiraConnector = SimpleServiceProvider.Current.GetInstance<JiraConnector>();
                 jiraConnector._jiraClient?.Behaviour.SetConfig(new SvgConfiguration

--- a/src/Greenshot.Plugin.Jira/JiraConnector.cs
+++ b/src/Greenshot.Plugin.Jira/JiraConnector.cs
@@ -58,13 +58,13 @@ public sealed class JiraConnector : IDisposable
     {
         CoreConfig.PropertyChanged += (sender, args) =>
         {
-            if (args.PropertyName == nameof(CoreConfig.IconSize))
+            if (args.PropertyName == nameof(CoreConfig.MenuIconSize) || args.PropertyName == nameof(CoreConfig.IconSize))
             {
                 var jiraConnector = SimpleServiceProvider.Current.GetInstance<JiraConnector>();
                 jiraConnector._jiraClient?.Behaviour.SetConfig(new SvgConfiguration
                 {
-                    Width = CoreConfig.IconSize.Width,
-                    Height = CoreConfig.IconSize.Height
+                    Width = CoreConfig.MenuIconSize.Width,
+                    Height = CoreConfig.MenuIconSize.Height
                 });
             }
         };
@@ -112,8 +112,8 @@ public sealed class JiraConnector : IDisposable
         _jiraClient = JiraClient.Create(new Uri(JiraConfig.Url));
         _jiraClient.Behaviour.SetConfig(new SvgConfiguration
         {
-            Width = CoreConfig.IconSize.Width,
-            Height = CoreConfig.IconSize.Height
+            Width = CoreConfig.MenuIconSize.Width,
+            Height = CoreConfig.MenuIconSize.Height
         });
         _jiraClient.SetBasicAuthentication(user, password);
 

--- a/src/Greenshot/Controls/ContextMenuToolStripProfessionalRenderer.cs
+++ b/src/Greenshot/Controls/ContextMenuToolStripProfessionalRenderer.cs
@@ -44,7 +44,7 @@ namespace Greenshot.Controls
         }
         protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
         {
-            var newSize = DpiCalculator.ScaleWithDpi(CoreConfig.IconSize, _provideDeviceDpi.DeviceDpi);
+            var newSize = DpiCalculator.ScaleWithDpi(CoreConfig.MenuIconSize, _provideDeviceDpi.DeviceDpi);
             if (_scaledCheckbox == null || _scaledCheckbox.Size != newSize)
             {
                 _scaledCheckbox?.Dispose();

--- a/src/Greenshot/Controls/ToolStripMenuSelectList.cs
+++ b/src/Greenshot/Controls/ToolStripMenuSelectList.cs
@@ -60,7 +60,7 @@ namespace Greenshot.Controls
 
         private void UpdateImage()
         {
-            var newSize = DpiCalculator.ScaleWithDpi(CoreConfig.IconSize, _provideDeviceDpi.DeviceDpi);
+            var newSize = DpiCalculator.ScaleWithDpi(CoreConfig.MenuIconSize, _provideDeviceDpi.DeviceDpi);
             if (_defaultImage == null || _defaultImage.Size != newSize)
             {
                 _defaultImage?.Dispose();

--- a/src/Greenshot/Forms/AboutForm.Designer.cs
+++ b/src/Greenshot/Forms/AboutForm.Designer.cs
@@ -69,9 +69,8 @@ namespace Greenshot.Forms {
 			// 
 			// lblTitle
 			// 
-            var fontsize = (this.DeviceDpi / 96) * lblTitle.Font.Size;
             this.lblTitle.AutoSize = true;
-            this.lblTitle.Font = new System.Drawing.Font(System.Drawing.FontFamily.GenericSansSerif, fontsize, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblTitle.Font = new System.Drawing.Font(System.Drawing.FontFamily.GenericSansSerif, 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblTitle.Location = new System.Drawing.Point(108, 12);
 			this.lblTitle.Name = "lblTitle";
 			this.lblTitle.Size = new System.Drawing.Size(263, 19);
@@ -204,8 +203,6 @@ namespace Greenshot.Forms {
 			// 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            //this.AutoScaleDimensions = new System.Drawing.SizeF(96, 96);
-            //this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 
 			this.ClientSize = new System.Drawing.Size(530, 293);
 			this.Controls.Add(this.lblTranslation);

--- a/src/Greenshot/Forms/AboutForm.Designer.cs
+++ b/src/Greenshot/Forms/AboutForm.Designer.cs
@@ -201,8 +201,8 @@ namespace Greenshot.Forms {
 			// 
 			// AboutForm
 			// 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 
 			this.ClientSize = new System.Drawing.Size(530, 293);
 			this.Controls.Add(this.lblTranslation);

--- a/src/Greenshot/Forms/AboutForm.cs
+++ b/src/Greenshot/Forms/AboutForm.cs
@@ -154,6 +154,7 @@ namespace Greenshot.Forms
             pictureBox1.Image = _bitmap;
 
             lblTitle.Text = $@"Greenshot {EnvironmentInfo.GetGreenshotVersion()} {(IniConfig.IsPortable ? " Portable" : "")} ({OsInfo.Bits} bit) {(coreConfiguration.IsBetaTester ? "-IsBetaTester-":"")}";
+            lblTitle.Font = new Font(Font, FontStyle.Bold);
 
             // Number of frames the pixel animation takes
             int frames = FramesForMillis(2000);
@@ -210,6 +211,32 @@ namespace Greenshot.Forms
 
             // color animation for the background
             _backgroundAnimation = new ColorAnimator(BackColor, _backColor, FramesForMillis(5000), EasingType.Linear, EasingMode.EaseIn);
+        }
+
+        public void NormalizeFontsToForm()
+        {
+            SuspendLayout();
+            try
+            {
+                ApplyFontRecursive(this, Font);
+                lblTitle.Font = new Font(Font, FontStyle.Bold);
+            }
+            finally
+            {
+                ResumeLayout(true);
+            }
+        }
+
+        private static void ApplyFontRecursive(Control parent, Font font)
+        {
+            foreach (Control child in parent.Controls)
+            {
+                child.Font = font;
+                if (child.HasChildren)
+                {
+                    ApplyFontRecursive(child, font);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Greenshot/Forms/AboutForm.cs
+++ b/src/Greenshot/Forms/AboutForm.cs
@@ -50,6 +50,7 @@ namespace Greenshot.Forms
         private readonly Random _rand = new();
         private readonly Color _backColor = Color.FromArgb(61, 61, 61);
         private readonly Color _pixelColor = Color.FromArgb(138, 255, 0);
+        private Font _titleFont;
 
         // Variables used for the color-cycle
         private int _waitFrames;
@@ -127,6 +128,8 @@ namespace Greenshot.Forms
             if (_bitmap == null) return;
             _bitmap.Dispose();
             _bitmap = null;
+            _titleFont?.Dispose();
+            _titleFont = null;
         }
 
         /// <summary>
@@ -154,7 +157,7 @@ namespace Greenshot.Forms
             pictureBox1.Image = _bitmap;
 
             lblTitle.Text = $@"Greenshot {EnvironmentInfo.GetGreenshotVersion()} {(IniConfig.IsPortable ? " Portable" : "")} ({OsInfo.Bits} bit) {(coreConfiguration.IsBetaTester ? "-IsBetaTester-":"")}";
-            lblTitle.Font = new Font(Font, FontStyle.Bold);
+            ApplyTitleFont();
 
             // Number of frames the pixel animation takes
             int frames = FramesForMillis(2000);
@@ -219,12 +222,28 @@ namespace Greenshot.Forms
             try
             {
                 ApplyFontRecursive(this, Font);
-                lblTitle.Font = new Font(Font, FontStyle.Bold);
+                ApplyTitleFont();
             }
             finally
             {
                 ResumeLayout(true);
             }
+        }
+
+        private void ApplyTitleFont()
+        {
+            if (_titleFont != null &&
+                _titleFont.FontFamily.Equals(Font.FontFamily) &&
+                Math.Abs(_titleFont.SizeInPoints - Font.SizeInPoints) < 0.01f &&
+                _titleFont.Style == FontStyle.Bold)
+            {
+                lblTitle.Font = _titleFont;
+                return;
+            }
+
+            _titleFont?.Dispose();
+            _titleFont = new Font(Font, FontStyle.Bold);
+            lblTitle.Font = _titleFont;
         }
 
         private static void ApplyFontRecursive(Control parent, Font font)

--- a/src/Greenshot/Forms/MainForm.Designer.cs
+++ b/src/Greenshot/Forms/MainForm.Designer.cs
@@ -189,7 +189,7 @@ namespace Greenshot.Forms {
 			// contextmenu_quicksettings
 			// 
 			this.contextmenu_quicksettings.Name = "contextmenu_quicksettings";
-			this.contextmenu_quicksettings.Size = new System.Drawing.Size(170, coreConfiguration.IconSize.Height + 8);
+			this.contextmenu_quicksettings.Size = new System.Drawing.Size(170, coreConfiguration.MenuIconSize.Height + 8);
 			// 
 			// contextmenu_settings
 			// 

--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -945,9 +945,24 @@ namespace Greenshot.Forms
                 {
                     using (_settingsForm = new SettingsForm())
                     {
-                        _settingsForm.StartPosition = FormStartPosition.CenterScreen;
                         var targetDpi = NativeDpiMethods.GetDpi(Cursor.Position);
-                        if (_settingsForm.DeviceDpi > 0 && targetDpi > 0 && _settingsForm.DeviceDpi != targetDpi)
+                        if (targetDpi <= 0)
+                        {
+                            targetDpi = 96;
+                        }
+
+                        var targetScreen = Screen.FromPoint(Cursor.Position);
+                        var targetArea = targetScreen.WorkingArea;
+
+                        // Reset to design-time baseline before creating the handle.
+                        _settingsForm.AutoScaleMode = AutoScaleMode.Dpi;
+                        _settingsForm.Font = new Font(_settingsForm.Font.FontFamily, 8.25f, FontStyle.Regular, GraphicsUnit.Point);
+                        _settingsForm.StartPosition = FormStartPosition.Manual;
+                        _settingsForm.Location = new Point(
+                            targetArea.Left + (targetArea.Width - _settingsForm.Width) / 2,
+                            targetArea.Top + (targetArea.Height - _settingsForm.Height) / 2);
+                        _ = _settingsForm.Handle;
+                        if (_settingsForm.DeviceDpi > 0 && _settingsForm.DeviceDpi != targetDpi)
                         {
                             var scaleFactor = targetDpi / (float)_settingsForm.DeviceDpi;
                             _settingsForm.Font = new Font(
@@ -957,7 +972,13 @@ namespace Greenshot.Forms
                                 GraphicsUnit.Point);
                             _settingsForm.Scale(new SizeF(scaleFactor, scaleFactor));
                         }
+                        _settingsForm.PerformLayout();
+                        _settingsForm.Location = new Point(
+                            targetArea.Left + (targetArea.Width - _settingsForm.Width) / 2,
+                            targetArea.Top + (targetArea.Height - _settingsForm.Height) / 2);
 
+                        Log.Debug(
+                            $"ShowSetting dpi target={targetDpi}, device={_settingsForm.DeviceDpi}, size={_settingsForm.Size}, location={_settingsForm.Location}");
                         if (_settingsForm.ShowDialog() == DialogResult.OK)
                         {
                             InitializeQuickSettingsMenu();
@@ -993,17 +1014,26 @@ namespace Greenshot.Forms
                 {
                     using (_aboutForm = new AboutForm())
                     {
-                        // Handle mixed-DPI transitions: keep 100% at legacy baseline,
-                        // and only apply proportional correction for higher DPI mismatches.
                         var targetDpi = NativeDpiMethods.GetDpi(Cursor.Position);
-                        if (targetDpi <= 96)
+                        if (targetDpi <= 0)
                         {
-                            _aboutForm.Font = new Font(_aboutForm.Font.FontFamily, 8.25f, FontStyle.Regular, GraphicsUnit.Point);
-                            _aboutForm.NormalizeFontsToForm();
-                            _aboutForm.ClientSize = new Size(530, 293);
+                            targetDpi = 96;
                         }
+
+                        _aboutForm.AutoScaleMode = AutoScaleMode.Dpi;
+                        _aboutForm.Font = new Font(_aboutForm.Font.FontFamily, 8.25f, FontStyle.Regular, GraphicsUnit.Point);
+                        _aboutForm.ClientSize = new Size(530, 293);
+                        _aboutForm.NormalizeFontsToForm();
+                        _aboutForm.StartPosition = FormStartPosition.Manual;
+
+                        var targetScreen = Screen.FromPoint(Cursor.Position);
+                        var targetArea = targetScreen.WorkingArea;
+                        _aboutForm.Location = new Point(
+                            targetArea.Left + (targetArea.Width - _aboutForm.Width) / 2,
+                            targetArea.Top + (targetArea.Height - _aboutForm.Height) / 2);
+
                         _ = _aboutForm.Handle;
-                        if (targetDpi > 96 && _aboutForm.DeviceDpi > 0 && targetDpi > 0 && _aboutForm.DeviceDpi != targetDpi)
+                        if (_aboutForm.DeviceDpi > 0 && _aboutForm.DeviceDpi != targetDpi)
                         {
                             var scaleFactor = targetDpi / (float)_aboutForm.DeviceDpi;
                             _aboutForm.Font = new Font(
@@ -1012,13 +1042,11 @@ namespace Greenshot.Forms
                                 _aboutForm.Font.Style,
                                 GraphicsUnit.Point);
                             _aboutForm.Scale(new SizeF(scaleFactor, scaleFactor));
-                            _aboutForm.PerformLayout();
-                            _aboutForm.ClientSize = DpiCalculator.ScaleWithDpi(new Size(530, 293), targetDpi);
                         }
+                        _aboutForm.NormalizeFontsToForm();
+                        _aboutForm.ClientSize = DpiCalculator.ScaleWithDpi(new Size(530, 293), targetDpi);
+                        _aboutForm.PerformLayout();
 
-                        var targetScreen = Screen.FromPoint(Cursor.Position);
-                        var targetArea = targetScreen.WorkingArea;
-                        _aboutForm.StartPosition = FormStartPosition.Manual;
                         _aboutForm.Location = new Point(
                             targetArea.Left + (targetArea.Width - _aboutForm.Width) / 2,
                             targetArea.Top + (targetArea.Height - _aboutForm.Height) / 2);

--- a/src/Greenshot/Forms/MainForm.cs
+++ b/src/Greenshot/Forms/MainForm.cs
@@ -410,7 +410,7 @@ namespace Greenshot.Forms
             SoundHelper.Initialize();
 
             coreConfiguration.PropertyChanged += OnIconSizeChanged;
-            OnIconSizeChanged(this, new PropertyChangedEventArgs("IconSize"));
+            OnIconSizeChanged(this, new PropertyChangedEventArgs(nameof(coreConfiguration.MenuIconSize)));
 
             // Set the Greenshot icon visibility depending on the configuration. (Added for feature #3521446)
             // Setting it to true this late prevents Problems with the context menu
@@ -575,7 +575,7 @@ namespace Greenshot.Forms
         /// <param name="e">PropertyChangedEventArgs</param>
         private void OnIconSizeChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != "IconSize")
+            if (e.PropertyName != nameof(coreConfiguration.MenuIconSize))
             {
                 return;
             }
@@ -588,7 +588,7 @@ namespace Greenshot.Forms
         /// </summary>
         protected override void DpiChangedHandler(int oldDpi, int newDpi)
         {
-            var newSize = DpiCalculator.ScaleWithDpi(coreConfiguration.IconSize, newDpi);
+            var newSize = DpiCalculator.ScaleWithDpi(coreConfiguration.MenuIconSize, newDpi);
             contextMenu.ImageScalingSize = newSize;
         }
 
@@ -645,8 +645,10 @@ namespace Greenshot.Forms
 
         private void ContextMenuOpening(object sender, CancelEventArgs e)
         {
-            var factor = DeviceDpi / 96f;
-            contextMenu.Scale(new SizeF(factor, factor));
+            var menuDpi = NativeDpiMethods.GetDpi(Cursor.Position);
+            contextMenu.ImageScalingSize = DpiCalculator.ScaleWithDpi(coreConfiguration.MenuIconSize, menuDpi);
+            var menuFontSize = DpiCalculator.ScaleWithDpi(12f, menuDpi);
+            contextMenu.Font = new Font(FontFamily.GenericSansSerif, menuFontSize, FontStyle.Regular, GraphicsUnit.Pixel);
             contextmenu_captureclipboard.Enabled = ClipboardHelper.ContainsImage();
             contextmenu_capturelastregion.Enabled = coreConfiguration.LastCapturedRegion != NativeRect.Empty;
 
@@ -943,6 +945,19 @@ namespace Greenshot.Forms
                 {
                     using (_settingsForm = new SettingsForm())
                     {
+                        _settingsForm.StartPosition = FormStartPosition.CenterScreen;
+                        var targetDpi = NativeDpiMethods.GetDpi(Cursor.Position);
+                        if (_settingsForm.DeviceDpi > 0 && targetDpi > 0 && _settingsForm.DeviceDpi != targetDpi)
+                        {
+                            var scaleFactor = targetDpi / (float)_settingsForm.DeviceDpi;
+                            _settingsForm.Font = new Font(
+                                _settingsForm.Font.FontFamily,
+                                _settingsForm.Font.SizeInPoints * scaleFactor,
+                                _settingsForm.Font.Style,
+                                GraphicsUnit.Point);
+                            _settingsForm.Scale(new SizeF(scaleFactor, scaleFactor));
+                        }
+
                         if (_settingsForm.ShowDialog() == DialogResult.OK)
                         {
                             InitializeQuickSettingsMenu();
@@ -978,7 +993,36 @@ namespace Greenshot.Forms
                 {
                     using (_aboutForm = new AboutForm())
                     {
-                        _aboutForm.ShowDialog(this);
+                        // Handle mixed-DPI transitions: keep 100% at legacy baseline,
+                        // and only apply proportional correction for higher DPI mismatches.
+                        var targetDpi = NativeDpiMethods.GetDpi(Cursor.Position);
+                        if (targetDpi <= 96)
+                        {
+                            _aboutForm.Font = new Font(_aboutForm.Font.FontFamily, 8.25f, FontStyle.Regular, GraphicsUnit.Point);
+                            _aboutForm.NormalizeFontsToForm();
+                            _aboutForm.ClientSize = new Size(530, 293);
+                        }
+                        _ = _aboutForm.Handle;
+                        if (targetDpi > 96 && _aboutForm.DeviceDpi > 0 && targetDpi > 0 && _aboutForm.DeviceDpi != targetDpi)
+                        {
+                            var scaleFactor = targetDpi / (float)_aboutForm.DeviceDpi;
+                            _aboutForm.Font = new Font(
+                                _aboutForm.Font.FontFamily,
+                                _aboutForm.Font.SizeInPoints * scaleFactor,
+                                _aboutForm.Font.Style,
+                                GraphicsUnit.Point);
+                            _aboutForm.Scale(new SizeF(scaleFactor, scaleFactor));
+                            _aboutForm.PerformLayout();
+                            _aboutForm.ClientSize = DpiCalculator.ScaleWithDpi(new Size(530, 293), targetDpi);
+                        }
+
+                        var targetScreen = Screen.FromPoint(Cursor.Position);
+                        var targetArea = targetScreen.WorkingArea;
+                        _aboutForm.StartPosition = FormStartPosition.Manual;
+                        _aboutForm.Location = new Point(
+                            targetArea.Left + (targetArea.Width - _aboutForm.Width) / 2,
+                            targetArea.Top + (targetArea.Height - _aboutForm.Height) / 2);
+                        _aboutForm.ShowDialog();
                     }
                 }
                 finally

--- a/src/Greenshot/Forms/SettingsForm.Designer.cs
+++ b/src/Greenshot/Forms/SettingsForm.Designer.cs
@@ -98,6 +98,8 @@ namespace Greenshot.Forms {
 			this.fullscreen_hotkeyControl = new HotkeyControl();
 			this.tab_capture = new GreenshotTabPage();
 			this.groupbox_editor = new GreenshotGroupBox();
+			this.numericUpdownMenuIconSize = new System.Windows.Forms.NumericUpDown();
+			this.label_menu_icon_size = new GreenshotLabel();
 			this.numericUpdownIconSize = new System.Windows.Forms.NumericUpDown();
 			this.label_icon_size = new GreenshotLabel();
 			this.checkbox_editor_match_capture_size = new GreenshotCheckBox();
@@ -315,13 +317,15 @@ namespace Greenshot.Forms {
 			// 
 			this.groupbox_applicationsettings.Controls.Add(this.label_language);
 			this.groupbox_applicationsettings.Controls.Add(this.combobox_language);
+			this.groupbox_applicationsettings.Controls.Add(this.numericUpdownMenuIconSize);
+			this.groupbox_applicationsettings.Controls.Add(this.label_menu_icon_size);
 			this.groupbox_applicationsettings.Controls.Add(this.numericUpdownIconSize);
 			this.groupbox_applicationsettings.Controls.Add(this.label_icon_size);
 			this.groupbox_applicationsettings.Controls.Add(this.checkbox_autostartshortcut);
 			this.groupbox_applicationsettings.LanguageKey = "settings_applicationsettings";
 			this.groupbox_applicationsettings.Location = new System.Drawing.Point(2, 6);
 			this.groupbox_applicationsettings.Name = "groupbox_applicationsettings";
-			this.groupbox_applicationsettings.Size = new System.Drawing.Size(412, 89);
+			this.groupbox_applicationsettings.Size = new System.Drawing.Size(412, 112);
 			this.groupbox_applicationsettings.TabIndex = 14;
 			this.groupbox_applicationsettings.TabStop = false;
 			// 
@@ -334,6 +338,24 @@ namespace Greenshot.Forms {
 			this.numericUpdownIconSize.Maximum = 256;
 			this.numericUpdownIconSize.Minimum = 16;
 			this.numericUpdownIconSize.Increment = 16;
+			// 
+			// numericUpdownMenuIconSize
+			// 
+			this.numericUpdownMenuIconSize.Location = new System.Drawing.Point(359, 63);
+			this.numericUpdownMenuIconSize.Name = "numericUpdownMenuIconSize";
+			this.numericUpdownMenuIconSize.Size = new System.Drawing.Size(44, 20);
+			this.numericUpdownMenuIconSize.TabIndex = 2;
+			this.numericUpdownMenuIconSize.Maximum = 256;
+			this.numericUpdownMenuIconSize.Minimum = 16;
+			this.numericUpdownMenuIconSize.Increment = 16;
+			// 
+			// label_menu_icon_size
+			// 
+			this.label_menu_icon_size.Location = new System.Drawing.Point(6, 65);
+			this.label_menu_icon_size.Name = "label_menu_icon_size";
+			this.label_menu_icon_size.Size = new System.Drawing.Size(350, 20);
+			this.label_menu_icon_size.TabIndex = 7;
+			this.label_menu_icon_size.Text = "Tray/menu icon size";
 			// 
 			// label_icon_size
 			// 
@@ -1212,8 +1234,8 @@ namespace Greenshot.Forms {
 			// 
 			// SettingsForm
 			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 14F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.ClientSize = new System.Drawing.Size(451, 431);
 			this.Controls.Add(this.tabcontrol);
 			this.Controls.Add(this.settings_confirm);
@@ -1354,6 +1376,8 @@ namespace Greenshot.Forms {
         private GreenshotCheckBox checkboxAllowCenter;
 		private GreenshotCheckBox checkbox_zoomer;
 		private GreenshotLabel label_icon_size;
+		private GreenshotLabel label_menu_icon_size;
 		private System.Windows.Forms.NumericUpDown numericUpdownIconSize;
+		private System.Windows.Forms.NumericUpDown numericUpdownMenuIconSize;
 	}
 }

--- a/src/Greenshot/Forms/SettingsForm.cs
+++ b/src/Greenshot/Forms/SettingsForm.cs
@@ -104,6 +104,11 @@ namespace Greenshot.Forms
             DisplayPluginTab();
             UpdateUi();
             ExpertSettingsEnableState(false);
+            // Icon sizes are now DPI-driven; keep the legacy numeric settings hidden.
+            label_icon_size.Visible = false;
+            numericUpdownIconSize.Visible = false;
+            label_menu_icon_size.Visible = false;
+            numericUpdownMenuIconSize.Visible = false;
             DisplaySettings();
             CheckSettings();
         }
@@ -419,7 +424,7 @@ namespace Greenshot.Forms
             checkbox_picker.Checked = false;
 
             listview_destinations.Items.Clear();
-            var scaledIconSize = DpiCalculator.ScaleWithDpi(coreConfiguration.IconSize, NativeDpiMethods.GetDpi(Handle));
+            var scaledIconSize = DpiCalculator.ScaleWithDpi(coreConfiguration.MenuIconSize, NativeDpiMethods.GetDpi(Handle));
             listview_destinations.ListViewItemSorter = new ListviewWithDestinationComparer();
             ImageList imageList = new ImageList
             {
@@ -531,7 +536,8 @@ namespace Greenshot.Forms
 
             numericUpDown_daysbetweencheck.Value = coreConfiguration.UpdateCheckInterval;
             numericUpDown_daysbetweencheck.Enabled = !coreConfiguration.Values["UpdateCheckInterval"].IsFixed;
-            numericUpdownIconSize.Value = coreConfiguration.IconSize.Width;
+            numericUpdownIconSize.Value = coreConfiguration.EditorIconSize.Width;
+            numericUpdownMenuIconSize.Value = coreConfiguration.MenuIconSize.Width;
             CheckDestinationSettings();
         }
 
@@ -588,7 +594,8 @@ namespace Greenshot.Forms
             coreConfiguration.DWMBackgroundColor = colorButton_window_background.SelectedColor;
             coreConfiguration.UpdateCheckInterval = (int) numericUpDown_daysbetweencheck.Value;
 
-            coreConfiguration.IconSize = new Size((int) numericUpdownIconSize.Value, (int) numericUpdownIconSize.Value);
+            coreConfiguration.EditorIconSize = new Size((int) numericUpdownIconSize.Value, (int) numericUpdownIconSize.Value);
+            coreConfiguration.MenuIconSize = new Size((int) numericUpdownMenuIconSize.Value, (int) numericUpdownMenuIconSize.Value);
 
             try
             {

--- a/src/Greenshot/Forms/SettingsForm.cs
+++ b/src/Greenshot/Forms/SettingsForm.cs
@@ -594,8 +594,13 @@ namespace Greenshot.Forms
             coreConfiguration.DWMBackgroundColor = colorButton_window_background.SelectedColor;
             coreConfiguration.UpdateCheckInterval = (int) numericUpDown_daysbetweencheck.Value;
 
-            coreConfiguration.EditorIconSize = new Size((int) numericUpdownIconSize.Value, (int) numericUpdownIconSize.Value);
-            coreConfiguration.MenuIconSize = new Size((int) numericUpdownMenuIconSize.Value, (int) numericUpdownMenuIconSize.Value);
+            // Legacy icon-size controls are hidden when automatic DPI scaling is active.
+            // Avoid writing stale hidden control values back into configuration.
+            if (numericUpdownIconSize.Visible && numericUpdownMenuIconSize.Visible)
+            {
+                coreConfiguration.EditorIconSize = new Size((int) numericUpdownIconSize.Value, (int) numericUpdownIconSize.Value);
+                coreConfiguration.MenuIconSize = new Size((int) numericUpdownMenuIconSize.Value, (int) numericUpdownMenuIconSize.Value);
+            }
 
             try
             {


### PR DESCRIPTION
## Summary
- Complete High DPI behavior across Greenshot UI with monitor-aware scaling for editor, tray/popup menus, settings, and dialogs.
- Split icon sizing concerns into editor vs menu/tray paths and update all relevant callsites/plugins.
- Fix mixed-DPI runtime issues (100%/200% transitions), including color picker and editor picker/menu readability.
- Hide legacy manual icon-size controls in Preferences now that scaling is automatic.

## Key behavior changes
- Editor, tray, and popup menu icons scale automatically with monitor DPI.
- Editor font/line thickness pickers and zoom menu readability are corrected at 100% and higher scales.
- Settings window scales correctly after monitor DPI changes.
- About dialog uses mixed-DPI handling with 100% baseline behavior preserved.

## Test plan
- [ ] Start app at 100% and verify tray menu, popup menu, editor toolbar, settings, and about dialog scale correctly.
- [ ] Start app at 200% and verify the same surfaces.
- [ ] Change Windows scaling 200% -> 100% without restart; verify settings/about/editor/color picker/menu behavior.
- [ ] Change Windows scaling 100% -> 200% without restart; verify same behavior.
- [ ] Verify Preferences no longer shows Icon size / Tray-menu icon size controls.