### PR TITLE
Update PixelizationFilter.cs

### DIFF
--- a/src/Greenshot.Editor/Drawing/Filters/PixelizationFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/PixelizationFilter.cs
@@ -44,25 +44,25 @@ namespace Greenshot.Editor.Drawing.Filters
         public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
         {
             int pixelSize = GetFieldValueAsInt(FieldType.PIXEL_SIZE);
-            ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-            if (pixelSize <= 1 || rect.Width == 0 || rect.Height == 0)
+            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
+            if (pixelSize <= 1 || applyRect.Width == 0 || applyRect.Height == 0)
             {
                 // Nothing to do
                 return;
             }
 
-            if (rect.Width < pixelSize)
+            if (applyRect.Width < pixelSize)
             {
-                pixelSize = rect.Width;
+                pixelSize = applyRect.Width;
             }
 
-            if (rect.Height < pixelSize)
+            if (applyRect.Height < pixelSize)
             {
-                pixelSize = rect.Height;
+                pixelSize = applyRect.Height;
             }
 
-            using IFastBitmap dest = FastBitmap.CreateCloneOf(applyBitmap, rect);
-            using (IFastBitmap src = FastBitmap.Create(applyBitmap, rect))
+            using IFastBitmap dest = FastBitmap.CreateCloneOf(applyBitmap, applyRect);
+            using (IFastBitmap src = FastBitmap.Create(applyBitmap, applyRect))
             {
                 List<Color> colors = new List<Color>();
                 int halbPixelSize = pixelSize / 2;
@@ -103,7 +103,7 @@ namespace Greenshot.Editor.Drawing.Filters
                 }
             }
 
-            dest.DrawTo(graphics, rect.Location);
+            dest.DrawTo(graphics, applyRect.Location);
         }
     }
 }


### PR DESCRIPTION
**Root cause**: PixelizationFilter.cs:47 called ImageHelper.CreateIntersectRectangle(...) but discarded the return value. Every other filter (BlurFilter, HighlightFilter) correctly captures it as applyRect and uses that clipped rectangle for all subsequent operations. PixelizationFilter kept using the raw rect parameter instead.

**What happens during crop**: After a crop is confirmed, the surface re-renders all existing drawables, including obfuscate elements. Each obfuscate element's rect is in the original image coordinate space. If that rect extends outside or partially outside the new (cropped) bitmap bounds, CreateIntersectRectangle returns the correctly clipped intersection — but since the result was thrown away, the original out-of-bounds rect was passed to FastBitmap.CreateCloneOf → ImageHelper.CloneArea → Bitmap.Clone, which throws ArgumentException when the width or height is 0 after the intersection.

**Fix**: Capture the return value as applyRect and use it everywhere in the method — matching the pattern in the sibling filter classes.

Fixes #1158