### PR TITLE
An idea to improve bug tracking

### DIFF
--- a/src/Greenshot/Configuration/LanguageKeys.cs
+++ b/src/Greenshot/Configuration/LanguageKeys.cs
@@ -77,6 +77,12 @@ namespace Greenshot.Configuration
         tooltip_firststart,
         warning,
         warning_hotkeys,
-        update_found
+        update_found,
+        missing_dependency_title,
+        missing_dependency_info,
+        missing_dependency_assembly_label,
+        missing_dependency_download,
+        missing_dependency_show_details,
+        missing_dependency_hide_details
     }
 }

--- a/src/Greenshot/Forms/MissingDependencyForm.Designer.cs
+++ b/src/Greenshot/Forms/MissingDependencyForm.Designer.cs
@@ -1,0 +1,164 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Greenshot.Base.Controls;
+
+namespace Greenshot.Forms
+{
+    partial class MissingDependencyForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.labelInfo = new GreenshotLabel();
+            this.labelAssemblyCaption = new GreenshotLabel();
+            this.labelMissingAssembly = new System.Windows.Forms.Label();
+            this.btnDownload = new GreenshotButton();
+            this.btnClose = new GreenshotButton();
+            this.linkDetails = new System.Windows.Forms.LinkLabel();
+            this.panelDetails = new System.Windows.Forms.Panel();
+            this.textBoxDetails = new System.Windows.Forms.TextBox();
+            this.panelDetails.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // labelInfo
+            //
+            this.labelInfo.LanguageKey = "missing_dependency_info";
+            this.labelInfo.Location = new System.Drawing.Point(12, 9);
+            this.labelInfo.Name = "labelInfo";
+            this.labelInfo.Size = new System.Drawing.Size(504, 80);
+            this.labelInfo.TabIndex = 0;
+            //
+            // labelAssemblyCaption
+            //
+            this.labelAssemblyCaption.LanguageKey = "missing_dependency_assembly_label";
+            this.labelAssemblyCaption.Location = new System.Drawing.Point(12, 97);
+            this.labelAssemblyCaption.Name = "labelAssemblyCaption";
+            this.labelAssemblyCaption.Size = new System.Drawing.Size(180, 20);
+            this.labelAssemblyCaption.TabIndex = 1;
+            //
+            // labelMissingAssembly
+            //
+            this.labelMissingAssembly.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            this.labelMissingAssembly.Location = new System.Drawing.Point(196, 97);
+            this.labelMissingAssembly.Name = "labelMissingAssembly";
+            this.labelMissingAssembly.Size = new System.Drawing.Size(320, 20);
+            this.labelMissingAssembly.TabIndex = 2;
+            //
+            // btnDownload
+            //
+            this.btnDownload.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnDownload.LanguageKey = "missing_dependency_download";
+            this.btnDownload.Location = new System.Drawing.Point(12, 128);
+            this.btnDownload.Name = "btnDownload";
+            this.btnDownload.Size = new System.Drawing.Size(200, 26);
+            this.btnDownload.TabIndex = 3;
+            this.btnDownload.UseVisualStyleBackColor = true;
+            this.btnDownload.Click += new System.EventHandler(this.BtnDownload_Click);
+            //
+            // btnClose
+            //
+            this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnClose.LanguageKey = "bugreport_cancel";
+            this.btnClose.Location = new System.Drawing.Point(389, 128);
+            this.btnClose.Name = "btnClose";
+            this.btnClose.Size = new System.Drawing.Size(139, 26);
+            this.btnClose.TabIndex = 4;
+            this.btnClose.UseVisualStyleBackColor = true;
+            //
+            // linkDetails
+            //
+            this.linkDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.linkDetails.AutoSize = true;
+            this.linkDetails.Location = new System.Drawing.Point(12, 164);
+            this.linkDetails.Name = "linkDetails";
+            this.linkDetails.TabIndex = 5;
+            this.linkDetails.TabStop = true;
+            this.linkDetails.Text = "Show technical details";
+            this.linkDetails.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkDetails_LinkClicked);
+            //
+            // panelDetails
+            //
+            this.panelDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                        | System.Windows.Forms.AnchorStyles.Left)
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelDetails.Controls.Add(this.textBoxDetails);
+            this.panelDetails.Location = new System.Drawing.Point(12, 185);
+            this.panelDetails.Name = "panelDetails";
+            this.panelDetails.Size = new System.Drawing.Size(516, 180);
+            this.panelDetails.TabIndex = 6;
+            this.panelDetails.Visible = false;
+            //
+            // textBoxDetails
+            //
+            this.textBoxDetails.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBoxDetails.Multiline = true;
+            this.textBoxDetails.Name = "textBoxDetails";
+            this.textBoxDetails.ReadOnly = true;
+            this.textBoxDetails.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.textBoxDetails.TabIndex = 0;
+            //
+            // MissingDependencyForm
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.CancelButton = this.btnClose;
+            this.ClientSize = new System.Drawing.Size(540, 375);
+            this.Controls.Add(this.panelDetails);
+            this.Controls.Add(this.linkDetails);
+            this.Controls.Add(this.btnClose);
+            this.Controls.Add(this.btnDownload);
+            this.Controls.Add(this.labelMissingAssembly);
+            this.Controls.Add(this.labelAssemblyCaption);
+            this.Controls.Add(this.labelInfo);
+            this.LanguageKey = "missing_dependency_title";
+            this.Name = "MissingDependencyForm";
+            this.Text = "Missing dependency";
+            this.panelDetails.ResumeLayout(false);
+            this.panelDetails.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private GreenshotLabel labelInfo;
+        private GreenshotLabel labelAssemblyCaption;
+        private System.Windows.Forms.Label labelMissingAssembly;
+        private GreenshotButton btnDownload;
+        private GreenshotButton btnClose;
+        private System.Windows.Forms.LinkLabel linkDetails;
+        private System.Windows.Forms.Panel panelDetails;
+        private System.Windows.Forms.TextBox textBoxDetails;
+    }
+}

--- a/src/Greenshot/Forms/MissingDependencyForm.cs
+++ b/src/Greenshot/Forms/MissingDependencyForm.cs
@@ -1,0 +1,89 @@
+/*
+ * Greenshot - a free and open source screenshot tool
+ * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
+ *
+ * For more information see: https://getgreenshot.org/
+ * The Greenshot project is hosted on GitHub https://github.com/greenshot/greenshot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+using Greenshot.Base.Core;
+using Greenshot.Configuration;
+
+namespace Greenshot.Forms
+{
+    public partial class MissingDependencyForm : BaseForm
+    {
+        private MissingDependencyForm()
+        {
+            InitializeComponent();
+            ToFront = true;
+        }
+
+        public MissingDependencyForm(Exception exception, string technicalDetails) : this()
+        {
+            textBoxDetails.Text = technicalDetails;
+            labelMissingAssembly.Text = ExtractAssemblyName(exception);
+        }
+
+        /// <summary>
+        /// Walks the exception chain and extracts the short assembly name from the first
+        /// "Could not load file or assembly '...'" message found.
+        /// Returns an empty string if none is found.
+        /// </summary>
+        private static string ExtractAssemblyName(Exception ex)
+        {
+            while (ex != null)
+            {
+                if (ex is FileNotFoundException)
+                {
+                    // Message format: "Could not load file or assembly 'Name, Version=...' or one of its dependencies."
+                    var match = Regex.Match(ex.Message, @"'([^,'"]+)");
+                    if (match.Success)
+                        return match.Groups[1].Value.Trim();
+                }
+                ex = ex.InnerException;
+            }
+            return string.Empty;
+        }
+
+        private void BtnDownload_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                Process.Start("https://getgreenshot.org/downloads/");
+            }
+            catch (Exception)
+            {
+                MessageBox.Show(
+                    Language.GetFormattedString(LangKey.error_openlink, "https://getgreenshot.org/downloads/"),
+                    Language.GetString(LangKey.error));
+            }
+        }
+
+        private void LinkDetails_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            panelDetails.Visible = !panelDetails.Visible;
+            linkDetails.Text = panelDetails.Visible
+                ? Language.GetString(LangKey.missing_dependency_hide_details)
+                : Language.GetString(LangKey.missing_dependency_show_details);
+        }
+    }
+}

--- a/src/Greenshot/GreenshotMain.cs
+++ b/src/Greenshot/GreenshotMain.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Threading;
@@ -107,6 +108,12 @@ public class GreenshotMain
             return;
         }
 
+        if (IsMissingDependencyException(exceptionToLog))
+        {
+            new MissingDependencyForm(exceptionToLog, exceptionText).ShowDialog();
+            return;
+        }
+
         new BugReportForm(exceptionText).ShowDialog();
     }
 
@@ -122,6 +129,12 @@ public class GreenshotMain
             return;
         }
 
+        if (IsMissingDependencyException(exceptionToLog))
+        {
+            new MissingDependencyForm(exceptionToLog, exceptionText).ShowDialog();
+            return;
+        }
+
         new BugReportForm(exceptionText).ShowDialog();
     }
 
@@ -133,11 +146,31 @@ public class GreenshotMain
             string exceptionText = EnvironmentInfo.BuildReport(exceptionToLog);
             LOG.Error("Exception caught in the UnobservedTaskException handler.");
             LOG.Error(exceptionText);
+            if (IsMissingDependencyException(exceptionToLog))
+            {
+                new MissingDependencyForm(exceptionToLog, exceptionText).ShowDialog();
+                return;
+            }
             new BugReportForm(exceptionText).ShowDialog();
         }
         finally
         {
             args.SetObserved();
         }
+    }
+
+    /// <summary>
+    /// Returns true when the exception (or any inner exception) is a missing assembly / dependency error.
+    /// This typically means the user installed Greenshot without the official installer.
+    /// </summary>
+    internal static bool IsMissingDependencyException(Exception ex)
+    {
+        while (ex != null)
+        {
+            if (ex is FileNotFoundException && ex.Message.Contains("Could not load file or assembly"))
+                return true;
+            ex = ex.InnerException;
+        }
+        return false;
     }
 }

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -12,6 +12,16 @@ Details about the GNU General Public License:</resource>
 		<resource name="about_translation"><!-- diplayed in about dialog, use to add credits or other translation-related info, e.g. "English translation by Jane Doe" --></resource>
 		<resource name="application_title">Greenshot - the revolutionary screenshot utility</resource>
 		<resource name="bugreport_cancel">Close</resource>
+		<resource name="missing_dependency_title">Greenshot could not start — missing file</resource>
+		<resource name="missing_dependency_info">Greenshot could not start because a required file is missing.
+
+This usually happens when Greenshot was not installed using the official installer, or when files were partially deleted or moved.
+
+To fix this, please download and run the official Greenshot installer.</resource>
+		<resource name="missing_dependency_assembly_label">Missing file:</resource>
+		<resource name="missing_dependency_download">Download official installer…</resource>
+		<resource name="missing_dependency_show_details">Show technical details</resource>
+		<resource name="missing_dependency_hide_details">Hide technical details</resource>
 		<resource name="bugreport_info">Sorry, an unexpected error occurred.
 
 The good news is: you can help us getting rid of it by filing a bug report.


### PR DESCRIPTION
Users who encounter a missing dependency error — typically because they extracted Greenshot from a zip or copied files manually rather than using the official installer — currently receive the same generic crash dialog as someone who hit a real bug. That dialog tells them to file a bug report, which is the wrong action entirely: there is no bug to report, the installation is simply incomplete. This creates noise on the issue tracker (maintainers spend time triaging reports that are not defects), and it leaves the user with no actionable guidance at a moment when they just want to know why the tool won't start. The change is small and entirely additive — it detects a specific, well-defined exception type (FileNotFoundException with "Could not load file or assembly" in the message), routes it to a separate dialog that names the missing file, explains the likely cause in plain language, and offers a direct link to the official installer. The generic bug reporter is untouched and handles everything else exactly as before. The cost of merging this is low; the benefit is that a frustrated user gets a clear answer instead of a confusing one.

May have stopped #1157 #1100 and #836 plus others also?