### PR TITLE
Update AbstractDestination.cs

### DIFF
--- a/src/Greenshot.Base/Core/AbstractDestination.cs
+++ b/src/Greenshot.Base/Core/AbstractDestination.cs
@@ -225,11 +225,11 @@ namespace Greenshot.Base.Core
                         break;
                     case ToolStripDropDownCloseReason.Keyboard:
                         // Menu closed via keyboard (e.g., ESC key)
-                        if (!captureDetails.HasDestination("Editor"))
+                        if (!captureDetails.HasDestination("Editor") && surface != null)
                         {
                             surface.Dispose();
                             surface = null;
-                        } 
+                        }
                         // We might already be in the disposing process, so queue the disposal to avoid re-entrancy
                         menu.BeginInvoke(new Action(() =>
                         {
@@ -262,6 +262,13 @@ namespace Greenshot.Base.Core
                         IDestination clickedDestination = (IDestination) toolStripMenuItem?.Tag;
                         if (clickedDestination == null)
                         {
+                            return;
+                        }
+
+                        // Guard against re-entrant clicks after the surface has already been disposed
+                        if (surface == null)
+                        {
+                            Log.Warn("Destination click handler invoked after surface was already disposed; ignoring.");
                             return;
                         }
 


### PR DESCRIPTION
Root cause: The ShowPickerMenu method captures surface in a closure shared by all the destination click handlers and the menu close handler. After a successful export, surface.Dispose() is called and surface is set to null. If the click handler fires again (e.g. due to event handler re-entrancy, a double-click, or WndProc processing a queued mouse-up after the menu was already closed), it calls clickedDestination.ExportCapture(true, null, captureDetails) — passing null as the surface — which causes the NullReferenceException.

Fixes made in AbstractDestination.cs:

Line ~268 — Added a null guard in the destination click handler: if surface has already been disposed and set to null, log a warning and return early instead of proceeding with a null surface.

Line ~230 — Added a null check in the Keyboard close handler before calling surface.Dispose(), since the same closure variable could already be null if export succeeded before ESC was pressed.

The "opened Excel" symptom on the first attempt is likely a separate usability issue (user may have hovered over Excel's submenu, which mutated its Tag before clicking Printer), but without the user being able to reproduce it consistently it may be incidental. The crash on subsequent attempts is definitively this null surface bug.

Fixes #1163