### PR TITLE
Updated the prepare-portable to take the correct files

### DIFF
--- a/installer/validate-installation.ps1
+++ b/installer/validate-installation.ps1
@@ -1,0 +1,14 @@
+Get-Content .\checksum.SHA256 | ForEach-Object {
+  $parts = $_ -split '  '; $expected = $parts[0]; $file = $parts[1]
+  if (Test-Path $file) {
+    $actual = (Get-FileHash $file -Algorithm SHA256).Hash
+    if ($actual -eq $expected) {
+        Write-Host "OK: $file" -ForegroundColor Green
+    }
+    else {
+        Write-Warning "FAILED: $file (Hash mismatch!)"
+    }
+  } else {
+    Write-Warning "MISSING: $file"
+  }
+}

--- a/prepare-portable.ps1
+++ b/prepare-portable.ps1
@@ -10,9 +10,10 @@ param(
 # Create portable directory
 New-Item -ItemType Directory -Path "$OutputPath" -Force | Out-Null
 
+# Copy checksum.SHA256
+Copy-Item "$BuildArtifactsPath\checksum.SHA256" "$OutputPath" -Force
 # Copy greenshot.exe
 Copy-Item "$BuildArtifactsPath\Greenshot.exe" "$OutputPath" -Force
-
 # Copy greenshot.exe.config
 Copy-Item "$BuildArtifactsPath\Greenshot.exe.config" "$OutputPath" -Force
 
@@ -41,10 +42,10 @@ Copy-Item "$RepositoryRootPath\src\Greenshot\Languages\*.xml" "$OutputPath\Langu
 ";In this file you should add your fixed settings" | Set-Content "$OutputPath\greenshot-fixed.ini" -Encoding UTF8
 
 # Copy license file
-Copy-Item "$RepositoryRootPath\installer\additional_files\license.txt" "$OutputPath" -Force
+Copy-Item "$RepositoryRootPath\src\Greenshot-Installer\additional_files\license.txt" "$OutputPath" -Force
 
 # Copy readme file
-Copy-Item "$RepositoryRootPath\installer\additional_files\readme.txt" "$OutputPath" -Force
+Copy-Item "$RepositoryRootPath\src\Greenshot-Installer\additional_files\readme.txt" "$OutputPath" -Force
 
 # Copy and rename log config file
 Copy-Item "$RepositoryRootPath\src\Greenshot\log4net-zip.xml" "$OutputPath\log4net.xml" -Force
@@ -73,17 +74,6 @@ New-Item -ItemType Directory -Path "$OutputPath\Plugins\Greenshot.Plugin.Externa
 Copy-Item "$RepositoryRootPath\src\Greenshot.Plugin.ExternalCommand\Languages\language_externalcommand*.xml" "$OutputPath\Languages\Greenshot.Plugin.ExternalCommand" -Force
 Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.ExternalCommand\Greenshot.Plugin.ExternalCommand.dll" "$OutputPath\Plugins\Greenshot.Plugin.ExternalCommand" -Force
 
-# Copy Flickr Plugin
-New-Item -ItemType Directory -Path "$OutputPath\Languages\Greenshot.Plugin.Flickr" -Force | Out-Null
-New-Item -ItemType Directory -Path "$OutputPath\Plugins\Greenshot.Plugin.Flickr" -Force | Out-Null
-Copy-Item "$RepositoryRootPath\src\Greenshot.Plugin.Flickr\Languages\language_flickr*.xml" "$OutputPath\Languages\Greenshot.Plugin.Flickr" -Force
-Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.Flickr\Greenshot.Plugin.Flickr.dll" "$OutputPath\Plugins\Greenshot.Plugin.Flickr" -Force
-
-# Copy GooglePhotos Plugin
-New-Item -ItemType Directory -Path "$OutputPath\Languages\Greenshot.Plugin.GooglePhotos" -Force | Out-Null
-New-Item -ItemType Directory -Path "$OutputPath\Plugins\Greenshot.Plugin.GooglePhotos" -Force | Out-Null
-Copy-Item "$RepositoryRootPath\src\Greenshot.Plugin.GooglePhotos\Languages\language_googlephotos*.xml" "$OutputPath\Languages\Greenshot.Plugin.GooglePhotos" -Force
-Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.GooglePhotos\Greenshot.Plugin.GooglePhotos.dll" "$OutputPath\Plugins\Greenshot.Plugin.GooglePhotos" -Force
 
 # Copy Imgur Plugin
 New-Item -ItemType Directory -Path "$OutputPath\Languages\Greenshot.Plugin.Imgur" -Force | Out-Null
@@ -102,9 +92,3 @@ Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.Jira\Dapplo.Jira.SvgWinF
 # Copy Office Plugin
 New-Item -ItemType Directory -Path "$OutputPath\Plugins\Greenshot.Plugin.Office" -Force | Out-Null
 Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.Office\Greenshot.Plugin.Office.dll" "$OutputPath\Plugins\Greenshot.Plugin.Office" -Force
-
-# Copy Photobucket Plugin
-New-Item -ItemType Directory -Path "$OutputPath\Languages\Greenshot.Plugin.Photobucket" -Force | Out-Null
-New-Item -ItemType Directory -Path "$OutputPath\Plugins\Greenshot.Plugin.Photobucket" -Force | Out-Null
-Copy-Item "$RepositoryRootPath\src\Greenshot.Plugin.Photobucket\Languages\language_photobucket*.xml" "$OutputPath\Languages\Greenshot.Plugin.Photobucket" -Force
-Copy-Item "$BuildArtifactsPath\Plugins\Greenshot.Plugin.Photobucket\Greenshot.Plugin.Photobucket.dll" "$OutputPath\Plugins\Greenshot.Plugin.Photobucket" -Force

--- a/src/Greenshot-Installer/Greenshot-Installer.csproj
+++ b/src/Greenshot-Installer/Greenshot-Installer.csproj
@@ -17,7 +17,8 @@
     <GetFileHash Files="@(FilesToHash)" Algorithm="SHA256" HashEncoding="hex">
       <Output TaskParameter="Items" ItemName="FilesWithHashes" />
     </GetFileHash>
-    <WriteLinesToFile File="$(SolutionDir)Greenshot\bin\$(Configuration)\$(TargetFramework)\checksum.SHA256" Lines="@(FilesWithHashes->'%(Filename)%(Extension): %(FileHash)')" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(SolutionDir)Greenshot\bin\$(Configuration)\$(TargetFramework)\checksum.SHA256" Lines="@(FilesWithHashes->'%(FileHash)  %(FullPath)')" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <Exec Command="powershell -NoProfile -Command &quot;$basePath = '$(SolutionDir)Greenshot\bin\$(Configuration)\$(TargetFramework)\'; $path = '$(SolutionDir)Greenshot\bin\$(Configuration)\$(TargetFramework)\checksum.SHA256'; $text = [System.IO.File]::ReadAllText($path); $text = $text -replace [regex]::Escape($basePath), '' -replace '\\', '/' -replace '\r\n', [char]10; [System.IO.File]::WriteAllText($path, $text)&quot;" />
   </Target>
 
   <UsingTask TaskName="SetEnvironmentVariableTask" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">


### PR DESCRIPTION
and added the checksum.SHA256.

Also modified the checksum.SHA256 to use the standard format as sha256sum uses, this would allow under linux sha256sum -c checksum.SHA256 to validate the installation. Added a powershell script to the repository to make the validation possible under windows.