### PR TITLE
Update Greenshot.Plugin.Office.csproj

### DIFF
--- a/src/Greenshot.Plugin.Office/Greenshot.Plugin.Office.csproj
+++ b/src/Greenshot.Plugin.Office/Greenshot.Plugin.Office.csproj
@@ -67,11 +67,11 @@
     </ItemGroup>
   </Target>
   <Target Name="EmbeddingMicrosoftOfficeCore" AfterTargets="ResolveReferences" BeforeTargets="FindReferenceAssembliesForReferences">
-    <PropertyGroup>
-      <_InteropAssemblyFileName>MicrosoftOfficeCore</_InteropAssemblyFileName>
-    </PropertyGroup>
     <ItemGroup>
-      <ReferencePath Condition=" '%(FileName)' == '$(_InteropAssemblyFileName)' AND '%(ReferencePath.NuGetPackageId)' == '$(_InteropAssemblyFileName)' ">
+      <!-- MicrosoftOfficeCore NuGet ships Office.dll (not MicrosoftOfficeCore.dll), so the filename
+           filter must be 'Office'. Without this match the type library is not embedded and Office 2007
+           users get a FileNotFoundException for 'office, Version=15.0.0.0' at runtime. -->
+      <ReferencePath Condition=" '%(FileName)' == 'Office' AND '%(ReferencePath.NuGetPackageId)' == 'MicrosoftOfficeCore' ">
         <EmbedInteropTypes>true</EmbedInteropTypes>
       </ReferencePath>
     </ItemGroup>


### PR DESCRIPTION
The crash reported by the user is caused by a typo in the MSBuild target responsible for embedding the MicrosoftOfficeCore type library into the plugin at build time.

The MicrosoftOfficeCore NuGet package ships a DLL named Office.dll, but the target was filtering by filename MicrosoftOfficeCore, a name that never matches anything.

Because the condition never fired, EmbedInteropTypes was never applied to the resolved reference, so .NET fell back to loading office, Version=15.0.0.0 as an external assembly at runtime 🤦‍♂️

Users on Office 2007 only have office, Version=12.0.0.0 on disk, so the load fails with a FileNotFoundException the moment they try to export to Excel.

Users on Office 2013 and newer were silently unaffected because Office, Version=15.0.0.0 exists on their machines, which masked the bug entirely during testing on modern installs.

The fix corrects the filename filter in the EmbeddingMicrosoftOfficeCore MSBuild target from MicrosoftOfficeCore to Office, matching the actual DLL name.

With this in place, the compiler extracts only the COM interface definitions Greenshot uses and embeds them directly into the plugin DLL.

The result has no runtime dependency on any version of office.dll — COM identity is based on interface GUIDs, which are stable across all Office versions from 2007 through 365, so the fix is safe for all users regardless of which Office version they have installed.

The change is a single-line condition correction in the .csproj. No C# code, runtime logic, or COM interop calls are touched.

Fixes #828
Fixes #1180