### PR TITLE
Fix French translations: missing keys and typos

### DIFF
--- a/src/Greenshot.Plugin.Box/Languages/language_box-fr-FR.xml
+++ b/src/Greenshot.Plugin.Box/Languages/language_box-fr-FR.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Français" ietf="fr-FR" version="1.0.0" languagegroup="">
 	<resources>
-		<resource name="communication_wait">Communication en cours avec le service de stockage en ligne. Veuillez patientez...</resource>
+		<resource name="communication_wait">Communication en cours avec le service de stockage en ligne. Veuillez patienter...</resource>
 		<resource name="Configure">Configurer Box</resource>
 		<resource name="label_AfterUpload">Après téléversement</resource>
 		<resource name="label_AfterUploadLinkToClipBoard">Copier le lien dans le presse-papier</resource>
@@ -9,6 +9,6 @@
 		<resource name="settings_title">Paramètres du stockage en ligne</resource>
 		<resource name="upload_failure">Une erreur s'est produite lors du téléversement vers le stockage en ligne :</resource>
 		<resource name="upload_menu_item">Téléverser vers le stockage en ligne</resource>
-		<resource name="upload_success">Image téléversée aves succès vers le stockage en ligne !</resource>
+		<resource name="upload_success">Image téléversée avec succès vers le stockage en ligne !</resource>
 	</resources>
 </language>

--- a/src/Greenshot.Plugin.Confluence/Languages/language_confluence-fr-FR.xml
+++ b/src/Greenshot.Plugin.Confluence/Languages/language_confluence-fr-FR.xml
@@ -3,6 +3,7 @@
 	<resources>
 		<resource name="browse_pages">Naviguer</resource>
 		<resource name="CANCEL">Annuler</resource>
+		<resource name="communication_wait">Transfert de données vers Confluence, veuillez patienter...</resource>
 		<resource name="copy_wikimarkup">Copier Wikimarkup vers le presse-papier</resource>
 		<resource name="filename">Fichier</resource>
 		<resource name="include_person_spaces">Inclure espaces personnels dans les recherches et la navigation</resource>
@@ -22,8 +23,8 @@
 		<resource name="search_text">Rechercher texte</resource>
 		<resource name="upload">Téléverser</resource>
 		<resource name="upload_failure">Une erreur s'est produite lors du téléversement vers Confluence :</resource>
-		<resource name="upload_format">Téléverser format</resource>
+		<resource name="upload_format">Format du téléversement</resource>
 		<resource name="upload_menu_item">Téléverser vers Confluence</resource>
-		<resource name="upload_success">Image téléversée aves succès vers Confluence !</resource>
+		<resource name="upload_success">Image téléversée avec succès vers Confluence !</resource>
 	</resources>
 </language>

--- a/src/Greenshot.Plugin.Dropbox/Languages/language_dropbox-fr-FR.xml
+++ b/src/Greenshot.Plugin.Dropbox/Languages/language_dropbox-fr-FR.xml
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Français" ietf="fr-FR" version="1.0.0" languagegroup="">
 	<resources>
-		<resource name="communication_wait">Communication en cours avec Dropbox. Veuillez patientez...</resource>
+		<resource name="communication_wait">Communication en cours avec Dropbox. Veuillez patienter...</resource>
 		<resource name="Configure">Configurer Dropbox</resource>
 		<resource name="label_AfterUpload">Après téléversement</resource>
+		<resource name="label_AfterUploadOpenHistory">Ouvrir l'historique</resource>
 		<resource name="label_AfterUploadLinkToClipBoard">Copier le lien dans le presse-papier</resource>
 		<resource name="label_upload_format">Format image</resource>
 		<resource name="settings_title">Paramètres Dropbox</resource>
 		<resource name="upload_failure">Une erreur s'est produite lors du téléversement vers Dropbox :</resource>
 		<resource name="upload_menu_item">Téléverser vers Dropbox</resource>
-		<resource name="upload_success">Image téléversée aves succès vers Dropbox !</resource>
+		<resource name="upload_success">Image téléversée avec succès vers Dropbox !</resource>
 	</resources>
 </language>

--- a/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-fr-FR.xml
+++ b/src/Greenshot.Plugin.ExternalCommand/Languages/language_externalcommand-fr-FR.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<language description="French" ietf="fr-FR" version="1.0.0">
+<language description="Français" ietf="fr-FR" version="1.0.0">
   <resources>
   <resource name="contextmenu_configure">
     Configuration de commandes externes 
   </resource>
   <resource name="settings_title">
-  		Paramètrage de la commande externe
+  		Paramétrage de la commande externe
 	</resource>
 	<resource name="settings_detail_title">
   		Configuration de la commande
@@ -17,7 +17,7 @@
   		Supprimer
 	</resource>
 	<resource name="settings_edit">
-  		Editer
+  		Éditer
 	</resource>
     <resource name="label_name">
       Nom

--- a/src/Greenshot.Plugin.Imgur/Languages/language_imgur-fr-FR.xml
+++ b/src/Greenshot.Plugin.Imgur/Languages/language_imgur-fr-FR.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <language description="Français" ietf="fr-FR" version="1.0.0" languagegroup="">
 	<resources>
+		<resource name="anonymous_access">Utiliser l'accès anonyme</resource>
 		<resource name="CANCEL">Annuler</resource>
 		<resource name="clear_question">Êtes-vous sûr(e) de vouloir supprimer l'historique local de Imgur ?</resource>
 		<resource name="communication_wait">Communication en cours avec Imgur. Veuillez patienter...</resource>

--- a/src/Greenshot/Languages/installer/language-installer-fr-FR.xml
+++ b/src/Greenshot/Languages/installer/language-installer-fr-FR.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<language description="French" ietf="fr-FR" version="1.0.1" languagegroup="1">
+<language description="Français" ietf="fr-FR" version="1.0.1" languagegroup="1">
 	<resources>
 		<resource name="confluence">Greffon Confluence</resource>
 		<resource name="externalcommand">Ouvrir avec le greffon de commande externe</resource>
@@ -7,7 +7,7 @@
 		<resource name="jira">Greffon Jira</resource>
 		<resource name="language">Langues additionnelles</resource>
 		<resource name="ocr">Greffon OCR (nécessite Document Imaging de Microsoft Office [MODI])</resource>
-		<resource name="optimize">Optimisation des performances, Ceci peut prendre un certain temps.</resource>
+		<resource name="optimize">Optimisation des performances. Ceci peut prendre un certain temps.</resource>
 		<resource name="startgreenshot">Démarrer {#ExeName}</resource>
 		<resource name="startup">Lancer {#ExeName} au démarrage de Windows</resource>
 	</resources>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -253,7 +253,7 @@ Veuillez vérifier l'accessibilité du répertoire de stockage.</resource>
 		<resource name="settings_capture">Capture</resource>
 		<resource name="settings_capture_mousepointer">Capturer le pointeur de la souris</resource>
 		<resource name="settings_capture_windows_interactive">Utiliser le mode interactif de capture de fenêtre</resource>
-		<resource name="settings_checkperiod">Intervalle de vérification des m.à.j. en jours (0=pas de vérification)</resource>
+		<resource name="settings_checkperiod">Intervalle de vérification des MÀJ en jours (0=pas de vérification)</resource>
 		<resource name="settings_configureplugin">Configurer</resource>
 		<resource name="settings_copypathtoclipboard">Copier le chemin vers le fichier dans le presse-papier à chaque sauvegarde</resource>
 		<resource name="settings_destination">Destination de la capture d'écran</resource>
@@ -306,7 +306,7 @@ en cours, par exemple 11_58_32 (plus l'extension définie dans les paramètres)<
 		<resource name="settings_showflashlight">Faire flasher l'écran</resource>
 		<resource name="settings_shownotify">Afficher les notifications</resource>
 		<resource name="settings_storagelocation">Rép. de sauvegarde</resource>
-		<resource name="settings_storagelocation_folder_error">L'explorateur de dossiers n'a pu être ouvert.
+		<resource name="settings_storagelocation_folder_error">Impossible d'ouvrir le sélecteur de dossiers.
 
 L'emplacement de stockage a été défini sur votre dossier Documents. Vous pouvez saisir un autre chemin directement dans le champ si nécessaire.</resource>
 		<resource name="settings_storagelocation_folder_error_title">Emplacement de stockage</resource>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -9,6 +9,7 @@
 Greenshot vous est fourni SANS AUCUNE GARANTIE. C'est un logiciel gratuit que vous êtes libres de redistribuer sous certaines conditions.
 Détails de la GNU General Public License :</resource>
 		<resource name="about_title">À propos de Greenshot</resource>
+		<resource name="about_translation"><!-- affiché dans la boîte de dialogue À propos, utiliser pour ajouter des crédits ou des informations liées à la traduction --></resource>
 		<resource name="application_title">Greenshot - l'utilitaire révolutionnaire de capture d'écran</resource>
 		<resource name="bugreport_cancel">Fermer</resource>
 		<resource name="bugreport_info">Désolé, une erreur inattendue s'est produite.
@@ -51,7 +52,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="contextmenu_capturefullscreen_top">haut</resource>
 		<resource name="contextmenu_capturelastregion">Capturer la dernière région</resource>
 		<resource name="contextmenu_capturewindow">Capturer la fenêtre active</resource>
-		<resource name="contextmenu_capturewindowfromlist">Capturer une fenêtre à partir la liste suivante</resource>
+		<resource name="contextmenu_capturewindowfromlist">Capturer une fenêtre à partir de la liste suivante</resource>
 		<resource name="contextmenu_donate">Soutenez Greenshot</resource>
 		<resource name="contextmenu_exit">Quitter</resource>
 		<resource name="contextmenu_help">Aide</resource>
@@ -75,6 +76,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_arrowheads_none">Aucun</resource>
 		<resource name="editor_arrowheads_start">Point d'origine</resource>
 		<resource name="editor_autocrop">Cadrage automatique</resource>
+		<resource name="editor_autocrop_not_possible">Cadrage automatique impossible</resource>
 		<resource name="editor_backcolor">Couleur de remplissage</resource>
 		<resource name="editor_blur_radius">Rayon du floutage</resource>
 		<resource name="editor_bold">Gras</resource>
@@ -92,7 +94,10 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_copytoclipboard">Copier</resource>
 		<resource name="editor_counter">Ajouter un compteur</resource>
 		<resource name="editor_crop">Recadrer (C)</resource>
+		<resource name="editor_crop_mode">Mode de recadrage</resource>
 		<resource name="editor_cropmode_default">Recadrer</resource>
+		<resource name="editor_cropmode_vertical">Recadrer verticalement</resource>
+		<resource name="editor_cropmode_horizontal">Recadrer horizontalement</resource>
 		<resource name="editor_cropmode_auto">Cadrage automatique</resource>
 		<resource name="editor_cursortool">Outil de sélection (ESC)</resource>
 		<resource name="editor_cuttoclipboard">Couper</resource>
@@ -108,7 +113,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_drawtextbox">Ajouter une boîte de texte (T)</resource>
 		<resource name="editor_dropshadow_darkness">Opacité de l'ombre</resource>
 		<resource name="editor_dropshadow_offset">Décalage</resource>
-		<resource name="editor_dropshadow_settings">Paramètrage de l'ombre</resource>
+		<resource name="editor_dropshadow_settings">Paramétrage de l'ombre</resource>
 		<resource name="editor_dropshadow_thickness">Épaisseur de l'ombre</resource>
 		<resource name="editor_duplicate">Dupliquer l'élément sélectionné</resource>
 		<resource name="editor_edit">Édition</resource>
@@ -142,6 +147,7 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_obfuscate_text_regex">Utiliser l'expression régulière</resource>
 		<resource name="editor_obfuscate_text_case_sensitive">Sensible à la casse</resource>
 		<resource name="editor_obfuscate_text_auto_search">Recherche automatique</resource>
+		<resource name="editor_obfuscate_text_advanced">Paramètres avancés</resource>
 		<resource name="editor_obfuscate_text_search_scope">Rechercher dans :</resource>
 		<resource name="editor_obfuscate_text_scope_words">Mots</resource>
 		<resource name="editor_obfuscate_text_scope_lines">Lignes</resource>
@@ -179,14 +185,14 @@ De plus, nous apprécierions beaucoup que vous preniez la peine de vérifier si 
 		<resource name="editor_speechbubble">Ajouter une bulle de texte</resource>
 		<resource name="editor_storedtoclipboard">L'image a été placée dans le presse-papier.</resource>
 		<resource name="editor_thickness">Épaisseur de ligne</resource>
-		<resource name="editor_title">Greenshot Éditeur d'Image</resource>
+		<resource name="editor_title">Éditeur d'image Greenshot</resource>
 		<resource name="editor_torn_edge">Bordures déchirées</resource>
 		<resource name="editor_tornedge_all">Déchirer tous les côtés</resource>
 		<resource name="editor_tornedge_bottom">Appliquer une déchirure en bas</resource>
 		<resource name="editor_tornedge_horizontaltoothrange">Horizontal : Intervalle des dents</resource>
 		<resource name="editor_tornedge_left">Appliquer une déchirure à gauche</resource>
 		<resource name="editor_tornedge_right">Appliquer une déchirure à droite</resource>
-		<resource name="editor_tornedge_settings">Paramètrage de la bordure</resource>
+		<resource name="editor_tornedge_settings">Paramétrage de la bordure</resource>
 		<resource name="editor_tornedge_shadow">Générer une ombre</resource>
 		<resource name="editor_tornedge_toothsize">Taille des dents</resource>
 		<resource name="editor_tornedge_top">Appliquer une déchirure en haut</resource>
@@ -240,21 +246,22 @@ Veuillez vérifier l'accessibilité du répertoire de stockage.</resource>
 		<resource name="qualitydialog_dontaskagain">Enregistrer en tant que qualité par défaut et ne plus le demander</resource>
 		<resource name="qualitydialog_title">Greenshot - Qualité</resource>
 		<resource name="quicksettings_destination_file">Enregistrer directement (utilise les préférences de sortie)</resource>
-		<resource name="settings_alwaysshowprintoptionsdialog">Afficher systématiquement la boite de dialogue d'impression.</resource>
+		<resource name="settings_alwaysshowprintoptionsdialog">Afficher systématiquement la boîte de dialogue d'impression.</resource>
 		<resource name="settings_alwaysshowqualitydialog">Afficher la boîte de dialogue de qualité à chaque enregistrement</resource>
 		<resource name="settings_applicationsettings">Paramètres de l'application</resource>
 		<resource name="settings_autostartshortcut">Lancer Greenshot au démarrage de Windows</resource>
 		<resource name="settings_capture">Capture</resource>
 		<resource name="settings_capture_mousepointer">Capturer le pointeur de la souris</resource>
 		<resource name="settings_capture_windows_interactive">Utiliser le mode interactif de capture de fenêtre</resource>
-		<resource name="settings_checkperiod">Intervalle de vérification des m.à.j en jours (0=pas de vérification)</resource>
+		<resource name="settings_checkperiod">Intervalle de vérification des m.à.j. en jours (0=pas de vérification)</resource>
 		<resource name="settings_configureplugin">Configurer</resource>
 		<resource name="settings_copypathtoclipboard">Copier le chemin vers le fichier dans le presse-papier à chaque sauvegarde</resource>
 		<resource name="settings_destination">Destination de la capture d'écran</resource>
 		<resource name="settings_destination_clipboard">Vers le presse-papier</resource>
 		<resource name="settings_destination_editor">Ouvrir dans l'éditeur d'image</resource>
+		<resource name="settings_destination_editor_add">Ajouter à l'éditeur</resource>
 		<resource name="settings_destination_email">Courriel</resource>
-		<resource name="settings_destination_file">Enregistrez directement (en utilisant les paramètres ci-dessous)</resource>
+		<resource name="settings_destination_file">Enregistrer directement (en utilisant les paramètres ci-dessous)</resource>
 		<resource name="settings_destination_fileas">Enregistrer sous (afficher la boîte de dialogue)</resource>
 		<resource name="settings_destination_picker">Demander la destination à chaque fois</resource>
 		<resource name="settings_destination_printer">Vers l'imprimante</resource>
@@ -299,12 +306,16 @@ en cours, par exemple 11_58_32 (plus l'extension définie dans les paramètres)<
 		<resource name="settings_showflashlight">Faire flasher l'écran</resource>
 		<resource name="settings_shownotify">Afficher les notifications</resource>
 		<resource name="settings_storagelocation">Rép. de sauvegarde</resource>
+		<resource name="settings_storagelocation_folder_error">L'explorateur de dossiers n'a pu être ouvert.
+
+L'emplacement de stockage a été défini sur votre dossier Documents. Vous pouvez saisir un autre chemin directement dans le champ si nécessaire.</resource>
+		<resource name="settings_storagelocation_folder_error_title">Emplacement de stockage</resource>
 		<resource name="settings_title">Paramètres</resource>
 		<resource name="settings_tooltip_filenamepattern">Modèle utilisé pour générer les noms de fichier lors de la sauvegarde des captures d'écran</resource>
 		<resource name="settings_tooltip_language">Langue de l'interface utilisateur de Greenshot</resource>
 		<resource name="settings_tooltip_primaryimageformat">Format d'image par défaut</resource>
 		<resource name="settings_tooltip_registerhotkeys">Détermine si les raccourcis clavier Impr. écran, Ctrl+Impr. écran, Alt+Impr. écran sont réservés à Greenshot lorsqu'il est en cours d'exécution.</resource>
-		<resource name="settings_tooltip_storagelocation">Répertoire où sont stockés vos captures d'écran par défaut. (Laisser vide pour sauvegarder sur le bureau)</resource>
+		<resource name="settings_tooltip_storagelocation">Répertoire où sont stockées vos captures d'écran par défaut. (Laisser vide pour sauvegarder sur le bureau)</resource>
 		<resource name="settings_usedefaultproxy">Utiliser le proxy système par défaut</resource>
 		<resource name="settings_visualization">Effets</resource>
 		<resource name="settings_waittime">Millisecondes d'attente avant la capture</resource>

--- a/src/Greenshot/Languages/website/language-website-fr-FR.xml
+++ b/src/Greenshot/Languages/website/language-website-fr-FR.xml
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<language description="French" ietf="fr-FR" version="1.0.0" languagegroup="1">
+<language description="Français" ietf="fr-FR" version="1.0.0" languagegroup="1">
 	<resources>
 		<resource name="home_downloads">Téléchargement</resource>
 		<resource name="home_headline">Greenshot - Un outil de capture d’écran gratuit pour une productivité optimale</resource>
 		<resource name="home_opensource">Greenshot est gratuit et «Open Source».</resource>
 		<resource name="home_opensource_donate">Si vous trouvez que Greenshot vous permet de faire des économies de temps et d’argent, vous êtes les bienvenus si vous nous apportez &lt;a href="/support/"&gt;votre support dans le développement&lt;/a&gt; de ce logiciel de capture d’écran.</resource>
 		<resource name="home_opensource_gpl">Greenshot a été publié sous &lt;a href="https://en.wikipedia.org/wiki/GNU_General_Public_License" target="_blank"&gt;GPL&lt;/a&gt;, à savoir que ce logiciel peut être utilisé gratuitement, même dans un environnement commercial.</resource>
-		<resource name="home_seemore">Voulez-vous en savoir plus?</resource>
-		<resource name="home_seemore_screenshots">Bien entendu Greenshot peut en faire beaucoup plus pour vous. Prenez la peine de regarder quelques &lt;a href="/screenshots/"&gt;captures d’écran&lt;/a&gt; de Greenshot en action ou essayer &lt;a title="Download the latest stable version of Greenshot" href="/downloads/"&gt;la dernière mise à niveau&lt;/a&gt;.</resource>
-		<resource name="home_whatis">Qu’est ce que Greenshot?</resource>
+		<resource name="home_seemore">Voulez-vous en savoir plus ?</resource>
+		<resource name="home_seemore_screenshots">Bien entendu Greenshot peut en faire beaucoup plus pour vous. Prenez la peine de regarder quelques &lt;a href="/screenshots/"&gt;captures d’écran&lt;/a&gt; de Greenshot en action ou essayez &lt;a title="Download the latest stable version of Greenshot" href="/downloads/"&gt;la dernière mise à niveau&lt;/a&gt;.</resource>
+		<resource name="home_whatis">Qu’est-ce que Greenshot ?</resource>
 		<resource name="home_whatis_create">Créer rapidement des captures d'une zone, d'une fenêtre ou d’un écran complet ; Il est même possible de capturer des pages web complètes (défilement) dans Internet Explorer.</resource>
 		<resource name="home_whatis_edit">Annoter, surligner, assombrir ou brouiller facilement des parties de la capture.</resource>
-		<resource name="home_whatis_intro">Greenshot est un logiciel de capture d’écran léger pour Windows avec les fonctionnalités majeures suivantes:</resource>
+		<resource name="home_whatis_intro">Greenshot est un logiciel de capture d’écran léger pour Windows avec les fonctionnalités majeures suivantes :</resource>
 		<resource name="home_whatis_more">...et bien d'autres options qui permettent de simplifier le travail de création ou de gestion journaliers des captures d’écran.</resource>
-		<resource name="home_whatis_send">Exporter la capture de multiples façons: sauvegarde vers un fichier, impression, copie dans le presse-papier, joindre à un courriel, envoi vers des programmes Office ou envoi vers des sites de photos comme Flickr ou Picasa, et d’autres encore.</resource>
-		<resource name="home_whatis_usage">Simple et facile à configurer, Greenshot est un outil efficace pour des responsables de projet, développeurs de logiciel, Concepteurs de manuels techniques, testeurs ou autres personnes créant des captures d’écran.</resource>
+		<resource name="home_whatis_send">Exporter la capture de multiples façons : sauvegarde vers un fichier, impression, copie dans le presse-papier, joindre à un courriel, envoi vers des programmes Office ou envoi vers des sites de photos comme Flickr ou Picasa, et d’autres encore.</resource>
+		<resource name="home_whatis_usage">Simple et facile à configurer, Greenshot est un outil efficace pour des responsables de projet, développeurs de logiciel, concepteurs de manuels techniques, testeurs ou autres personnes créant des captures d’écran.</resource>
 	</resources>
 </language>


### PR DESCRIPTION
## Summary

Full audit and cleanup of all `fr-FR` translation files in the main Greenshot project and its plugins. Fixes 12 missing resource keys and ~20 typos/grammar issues that had accumulated over time.

## Missing keys added

**`language-fr-FR.xml`** (9 keys):
`about_translation`, `editor_autocrop_not_possible`, `editor_crop_mode`, `editor_cropmode_horizontal`, `editor_cropmode_vertical`, `editor_obfuscate_text_advanced`, `settings_destination_editor_add`, `settings_storagelocation_folder_error`, `settings_storagelocation_folder_error_title`

**Plugins** (3 keys):
- `language_confluence-fr-FR.xml`: `communication_wait`
- `language_dropbox-fr-FR.xml`: `label_AfterUploadOpenHistory`
- `language_imgur-fr-FR.xml`: `anonymous_access`

## Typos & grammar fixes

| File | Fix |
|---|---|
| `language-fr-FR.xml` | « à partir **de** la liste », Para**mé**trage (×2), **boîte**, m.à.j**.**, **Enregistrer** directement, stock**ées**, « Éditeur d'image Greenshot » |
| `language_box-fr-FR.xml` | « Veuillez patien**ter** », « **avec** succès » |
| `language_dropbox-fr-FR.xml` | « Veuillez patien**ter** », « **avec** succès » |
| `language_confluence-fr-FR.xml` | « **avec** succès », « Format du téléversement » |
| `language_externalcommand-fr-FR.xml` | Para**mé**trage, **É**diter, `description="Français"` |
| `language-installer-fr-FR.xml` | Ponctuation corrigée, `description="Français"` |
| `language-website-fr-FR.xml` | Espaces avant `?` / `:`, « Qu'est-**ce** que », essay**ez**, **c**oncepteurs, `description="Français"` |

All eight files pass `xmllint` validation and every fr-FR file now has full key parity with its en-US counterpart.

## Test plan

- [x] `xmllint --noout` on all modified files
- [x] Key-set diff vs. `en-US` → no missing keys
- [ ] Load Greenshot in French and visually confirm the updated strings render correctly