### PR TITLE
Fixing a startup crash

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,6 @@
     <TargetFramework>net480</TargetFramework>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Deterministic>true</Deterministic>
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <!-- Emit Roslyn source-generator output to disk so Visual Studio IntelliSense can see
          the Dapplo.Ini-generated property implementations in *Impl.cs partial classes.
          The output path is inside obj/ so the auto-glob (**/*.cs) does NOT pick it up. -->

--- a/src/Greenshot.Base/Greenshot.Base.csproj
+++ b/src/Greenshot.Base/Greenshot.Base.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>none</DebugType>
@@ -22,7 +21,6 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="log4net" version="3.3.1" />
     <PackageReference Include="Svg" Version="3.4.7" />
-    <PackageReference Include="System.Resources.Extensions" Version="10.0.3" />
     <PackageReference Include="Dapplo.Ini" Version="1.0.149" />
     <PackageReference Include="Dapplo.Ini.Generator" Version="1.0.149" />
     <Reference Include="Accessibility" />


### PR DESCRIPTION
Fixes a startup crash (System.InvalidProgramException: Common Language Runtime detected an invalid program) that occurred during MainForm.InitializeComponent() when Greenshot tried to load embedded image resources.

The root cause was GenerateResourceUsePreserializedResources=true set in Directory.Build.props (and duplicated in Greenshot.Base.csproj), which instructs the MSBuild resource compiler to serialize .resx images using the pre-serialized binary format introduced for .NET 5+.

This format requires System.Resources.Extensions.DeserializingResourceReader at runtime — but the project targets net480 (.NET Framework 4.8), where the NuGet version of that library (v10.0.3, built for .NET 8+) generates code the .NET Framework CLR cannot execute.

The fix removes the GenerateResourceUsePreserializedResources property from both project files and drops the System.Resources.Extensions package reference, restoring the classic .resx image serialisation path that has always worked correctly on .NET Framework.

Fixes #1199