### PR TITLE
Update ImageEditorForm.cs

### DIFF
--- a/src/Greenshot.Editor/Forms/ImageEditorForm.cs
+++ b/src/Greenshot.Editor/Forms/ImageEditorForm.cs
@@ -1374,6 +1374,7 @@ namespace Greenshot.Editor.Forms
         /// </summary>
         private void RefreshFieldControls()
         {
+            if (IsDisposed || Disposing) return;
             propertiesToolStrip.SuspendLayout();
             if (_surface.HasSelectedElements || _surface.DrawingMode != DrawingModes.None)
             {
@@ -1413,6 +1414,7 @@ namespace Greenshot.Editor.Forms
 
         private void HideToolstripItems()
         {
+            if (IsDisposed || Disposing) return;
             foreach (ToolStripItem toolStripItem in propertiesToolStrip.Items)
             {
                 toolStripItem.Visible = false;
@@ -1424,6 +1426,7 @@ namespace Greenshot.Editor.Forms
         /// </summary>
         private void RefreshEditorControls()
         {
+            if (IsDisposed || Disposing) return;
             int stepLabels = _surface.CountStepLabels(null);
             Image icon;
             if (stepLabels <= 20)


### PR DESCRIPTION
The crash is a race between the form closing and mouse input being processed. The sequence:

User copies image to clipboard, then clicks somewhere on the surface to close/deselect SurfaceMouseDown fires → calls DeselectElements → RefreshEditorControls → RefreshFieldControls By the time RefreshFieldControls tries to set .Visible on toolbar controls (e.g. lineThicknessUpDown, which is a ToolStripControlHost), the form is already in a Disposing state ToolStripControlHost.SetVisibleCore in .NET Framework dereferences its internal Control reference, which is null after disposal → NullReferenceException Fix
Added if (IsDisposed || Disposing) return; guards at the top of three methods in ImageEditorForm.cs:

RefreshFieldControls (line 1377) — the direct crash site RefreshEditorControls (line 1427) — its caller; same exposure HideToolstripItems (line 1417) — also iterates and sets .Visible on hosted controls This is the standard WinForms pattern for preventing disposed-form UI access from event callbacks that arrive just as the form tears down.

Fixes #1169