### PR TITLE
Update ExcelDestination.cs

### DIFF
--- a/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
+++ b/src/Greenshot.Plugin.Office/Destinations/ExcelDestination.cs
@@ -88,6 +88,7 @@ namespace Greenshot.Plugin.Office.Destinations
             ExportInformation exportInformation = new ExportInformation(Designation, Description);
             bool createdFile = false;
             string imageFile = captureDetails.Filename;
+            Size imageSize = surface.Image?.Size ?? Size.Empty;
             if (imageFile == null || surface.Modified || !Regex.IsMatch(imageFile, @".*(\.png|\.gif|\.jpg|\.jpeg|\.tiff|\.bmp)$"))
             {
                 imageFile = ImageIO.SaveNamedTmpFile(surface, captureDetails, new SurfaceOutputSettings().PreventGreenshotFormat());
@@ -96,11 +97,11 @@ namespace Greenshot.Plugin.Office.Destinations
 
             if (_workbookName != null)
             {
-                ExcelExporter.InsertIntoExistingWorkbook(_workbookName, imageFile, surface.Image.Size);
+                ExcelExporter.InsertIntoExistingWorkbook(_workbookName, imageFile, imageSize);
             }
             else
             {
-                ExcelExporter.InsertIntoNewWorkbook(imageFile, surface.Image.Size);
+                ExcelExporter.InsertIntoNewWorkbook(imageFile, imageSize);
             }
 
             exportInformation.ExportMade = true;


### PR DESCRIPTION
Root cause: surface.Image can be null at the point ExportCapture is called (e.g. if the capture was cancelled or the surface hasn't been rendered yet). Both call sites — lines 99 and 103 — dereferenced .Size directly without a null check, causing the NullReferenceException.

Fix (ExcelDestination.cs:89): Read the image size once at the top of the method using surface.Image?.Size ?? Size.Empty, matching the same defensive pattern used in PowerpointDestination. If the image is null, Size.Empty is passed, which the Excel exporter handles gracefully (it simply sets shape dimensions to 0, and Excel will resize it anyway via ScaleHeight/ScaleWidth).

Fixes #1133