### PR TITLE
Document two-digit filename counters

### DIFF
--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -256,7 +256,8 @@ ${DD} day, 2 digits
 ${hh} hour, 2 digits
 ${mm} minute, 2 digits
 ${ss} second, 2 digits
-${NUM} incrementing number, 6 digits
+${NUM} incrementing number, 6 digits by default
+${NUM:p-2,0} incrementing number, 2 digits with leading zeros (01, 02, 03)
 ${RRR...} random alphanumerics, same length as 'R's
 ${title} Window title
 ${user} Windows user
@@ -264,6 +265,7 @@ ${domain} Windows domain
 ${hostname} PC name
 
 You can also have Greenshot create directories dynamically, simply use the backslash symbol (\) to separate folders and filename.
+To reset the ${NUM} counter, change its value in Expert settings.
 Example: the pattern ${YYYY}-${MM}-${DD}\${hh}-${mm}-${ss}
 will generate a folder for the current day in your default storage location, e.g. 2008-06-29, the contained screenshot file's name will be based on the current
 time, e.g. 11_58_32 (plus extension defined in the settings)</resource>


### PR DESCRIPTION
## Summary
- Document the existing `${NUM:p-2,0}` filename pattern for two-digit counters with leading zeros.
- Clarify that `${NUM}` remains six digits by default.
- Point users to Expert settings for resetting the `${NUM}` counter value.

Closes #1302.

## Verification
RED:
- A small XML/help-text guard failed before the edit because the English filename-pattern help did not mention `${NUM:p-2,0}` or Expert settings.

GREEN:
- `python3` XML/help-text guard: English language XML parses and contains `${NUM:p-2,0}`, `leading zeros (01, 02, 03)`, and `Expert settings`.
- `git -c core.whitespace=cr-at-eol diff --check`

## Notes
I could not run the full Visual Studio/.NET Framework build in this Linux environment because the repo requires Windows + Visual Studio/.NET Framework for the full solution build. This change is limited to the English language resource text.