### PR TITLE
Single draw for inverted filters with multiple areas

### DIFF
--- a/src/Greenshot.Editor/Drawing/CursorContainer.cs
+++ b/src/Greenshot.Editor/Drawing/CursorContainer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Greenshot - a free and open source screenshot tool
 * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
 * 
@@ -155,11 +155,11 @@ namespace Greenshot.Editor.Drawing
             CursorHelper.DrawCursorOnGraphics(graphics, cursor, Bounds.Location, Bounds.Size);
         }
 
-        public override void DrawContent(Graphics graphics, Bitmap bmp, RenderMode renderMode, NativeRect clipRectangle)
+        public override void DrawContent(Graphics graphics, Bitmap bmp, RenderMode renderMode, NativeRect clipRectangle, bool skipInvertedFilters = false)
         {
             if (bmp == null)
             {
-                base.DrawContent(graphics, bmp, renderMode, clipRectangle);
+                base.DrawContent(graphics, bmp, renderMode, clipRectangle, skipInvertedFilters);
                 return;
             }
 

--- a/src/Greenshot.Editor/Drawing/DrawableContainer.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainer.cs
@@ -424,7 +424,7 @@ namespace Greenshot.Editor.Drawing
             }
         }
 
-        public virtual void DrawContent(Graphics graphics, Bitmap bmp, RenderMode renderMode, NativeRect clipRectangle)
+        public virtual void DrawContent(Graphics graphics, Bitmap bmp, RenderMode renderMode, NativeRect clipRectangle, bool skipInvertedFilters = false)
         {
             if (Children.Count > 0)
             {
@@ -440,7 +440,10 @@ namespace Greenshot.Editor.Drawing
                         {
                             if (filter.Invert)
                             {
-                                filter.Apply(graphics, bmp, Bounds, renderMode);
+                                if (!skipInvertedFilters)
+                                {
+                                    filter.Apply(graphics, bmp, Bounds, renderMode);
+                                }
                             }
                             else
                             {

--- a/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
+++ b/src/Greenshot.Editor/Drawing/DrawableContainerList.cs
@@ -33,6 +33,7 @@ using Greenshot.Base.Interfaces;
 using Greenshot.Base.Interfaces.Drawing;
 using Greenshot.Editor.Configuration;
 using Greenshot.Editor.Drawing.Fields;
+using Greenshot.Editor.Drawing.Filters;
 using Greenshot.Editor.Forms;
 using Greenshot.Editor.Memento;
 
@@ -314,6 +315,33 @@ namespace Greenshot.Editor.Drawing
         }
 
         /// <summary>
+        /// Generates a group key based on the inverted filter types of a container,
+        /// used to combine matching inverted filters into a single draw operation.
+        /// </summary>
+        /// <param name="dc">The drawable container to inspect</param>
+        /// <returns>A comma-separated string of inverted filter type names, or null if no inverted filters exist.</returns>
+        private static string GetInvertedFilterGroupKey(DrawableContainer dc)
+        {
+            if (dc == null || !dc.HasFilters)
+            {
+                return null;
+            }
+
+            var invertedFilterTypes = dc.Filters
+                .Where(f => f.Invert)
+                .Select(f => f.GetType().FullName)
+                .OrderBy(name => name)
+                .ToList();
+
+            if (invertedFilterTypes.Count == 0)
+            {
+                return null;
+            }
+
+            return string.Join(",", invertedFilterTypes);
+        }
+
+        /// <summary>
         /// Triggers all elements in the list to be redrawn.
         /// </summary>
         /// <param name="g">the to the bitmap related Graphics object</param>
@@ -327,6 +355,30 @@ namespace Greenshot.Editor.Drawing
                 return;
             }
 
+            // Find all containers with inverted filters that should be combined
+            var invertedGroups = new Dictionary<string, List<DrawableContainer>>();
+            foreach (var drawableContainer in this)
+            {
+                var dc = (DrawableContainer) drawableContainer;
+                if (dc.Parent == null || !dc.HasFilters)
+                {
+                    continue;
+                }
+
+                string groupKey = GetInvertedFilterGroupKey(dc);
+                if (!string.IsNullOrEmpty(groupKey))
+                {
+                    if (!invertedGroups.TryGetValue(groupKey, out var list))
+                    {
+                        list = new List<DrawableContainer>();
+                        invertedGroups[groupKey] = list;
+                    }
+                    list.Add(dc);
+                }
+            }
+
+            var drawnGroups = new HashSet<string>();
+
             foreach (var drawableContainer in this)
             {
                 var dc = (DrawableContainer) drawableContainer;
@@ -337,7 +389,37 @@ namespace Greenshot.Editor.Drawing
 
                 if (dc.DrawingBounds.IntersectsWith(clipRectangle))
                 {
-                    dc.DrawContent(g, bitmap, renderMode, clipRectangle);
+                    string groupKey = GetInvertedFilterGroupKey(dc);
+                    if (!string.IsNullOrEmpty(groupKey))
+                    {
+                        if (!drawnGroups.Contains(groupKey) && bitmap != null)
+                        {
+                            drawnGroups.Add(groupKey);
+                            var groupContainers = invertedGroups[groupKey];
+                            var idleContainers = groupContainers.Where(c => c.Status == EditStatus.IDLE).ToList();
+                            if (idleContainers.Count > 0)
+                            {
+                                var allBounds = groupContainers.Select(c => c.Bounds).Where(b => b.Width > 0 && b.Height > 0).ToList();
+                                if (allBounds.Count > 0)
+                                {
+                                    var representative = groupContainers.FirstOrDefault(c => c.Selected) ?? idleContainers.First();
+                                    foreach (IFilter filter in representative.Filters)
+                                    {
+                                        if (filter.Invert)
+                                        {
+                                            filter.Apply(g, bitmap, allBounds, renderMode);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        dc.DrawContent(g, bitmap, renderMode, clipRectangle, skipInvertedFilters: true);
+                    }
+                    else
+                    {
+                        dc.DrawContent(g, bitmap, renderMode, clipRectangle, skipInvertedFilters: false);
+                    }
                 }
             }
         }

--- a/src/Greenshot.Editor/Drawing/Filters/AbstractFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/AbstractFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -20,8 +20,12 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using Dapplo.Windows.Common.Extensions;
 using Dapplo.Windows.Common.Structs;
 using Greenshot.Base.Interfaces.Drawing;
 using Greenshot.Editor.Drawing.Fields;
@@ -74,7 +78,97 @@ namespace Greenshot.Editor.Drawing.Filters
             return parent;
         }
 
-        public abstract void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode);
+        /// <summary>
+        /// Applies the filter to a single rectangle.
+        /// By default, delegates to the multi-rectangle Apply overload.
+        /// </summary>
+        public virtual void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
+        {
+            Apply(graphics, applyBitmap, new[] { rect }, renderMode);
+        }
+
+        /// <summary>
+        /// Applies the filter to one or more rectangles with clipping and graphics state management.
+        /// </summary>
+        public virtual void Apply(Graphics graphics, Bitmap applyBitmap, IEnumerable<NativeRect> rects, RenderMode renderMode)
+        {
+            ApplyWithClipping(graphics, applyBitmap, rects, applyRect => ApplyFilter(graphics, applyBitmap, applyRect, renderMode));
+        }
+
+        /// <summary>
+        /// Renders the filter effect onto the graphics surface within the applyRect bounds.
+        /// When this method is called, clipping has already been configured on the graphics context
+        /// (handling Invert exclusions or non-inverted inclusion path), and graphics state is restored automatically.
+        /// Subclasses implementing area/image filters should override this method.
+        /// </summary>
+        protected virtual void ApplyFilter(Graphics graphics, Bitmap applyBitmap, NativeRect applyRect, RenderMode renderMode)
+        {
+        }
+
+        /// <summary>
+        /// Executes the given render action within a clipped region for the specified rectangles.
+        /// Handles graphics state saving and restoring, bounding rectangle calculation,
+        /// and clipping (including multi-rectangle inverted exclusion).
+        /// </summary>
+        protected void ApplyWithClipping(Graphics graphics, Bitmap applyBitmap, IEnumerable<NativeRect> rects, Action<NativeRect> renderAction)
+        {
+            if (graphics == null || applyBitmap == null || renderAction == null)
+            {
+                return;
+            }
+
+            var rectList = rects as IList<NativeRect> ?? rects?.ToList() ?? new List<NativeRect>();
+            if (rectList.Count == 0)
+            {
+                return;
+            }
+
+            NativeRect applyRect;
+            if (Invert)
+            {
+                applyRect = new NativeRect(0, 0, applyBitmap.Width, applyBitmap.Height);
+            }
+            else
+            {
+                applyRect = rectList.Aggregate(NativeRect.Empty, (current, r) => current.IsEmpty ? r : current.Union(r))
+                                    .Intersect(new NativeRect(0, 0, applyBitmap.Width, applyBitmap.Height));
+            }
+
+            if (applyRect.Width <= 0 || applyRect.Height <= 0)
+            {
+                return;
+            }
+
+            GraphicsState state = graphics.Save();
+            try
+            {
+                if (Invert)
+                {
+                    graphics.SetClip(applyRect);
+                    foreach (var rect in rectList)
+                    {
+                        graphics.ExcludeClip(rect);
+                    }
+                }
+                else
+                {
+                    using (GraphicsPath path = new GraphicsPath())
+                    {
+                        foreach (var rect in rectList)
+                        {
+                            path.AddRectangle(rect);
+                        }
+                        graphics.SetClip(path);
+                    }
+                }
+
+                renderAction(applyRect);
+            }
+            finally
+            {
+                graphics.Restore(state);
+            }
+        }
 
         protected void OnPropertyChanged(string propertyName)
         {

--- a/src/Greenshot.Editor/Drawing/Filters/BlurFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/BlurFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -21,7 +21,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using Dapplo.Windows.Common.Structs;
 using Dapplo.Windows.Gdi32;
 using Greenshot.Base.Core;
@@ -51,34 +50,21 @@ namespace Greenshot.Editor.Drawing.Filters
             AddField(GetType(), FieldType.PREVIEW_QUALITY, 1.0d);
         }
 
-        public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
+        protected override void ApplyFilter(Graphics graphics, Bitmap applyBitmap, NativeRect applyRect, RenderMode renderMode)
         {
             int blurRadius = GetFieldValueAsInt(FieldType.BLUR_RADIUS);
-            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-            if (applyRect.Width == 0 || applyRect.Height == 0)
-            {
-                return;
-            }
-
-            GraphicsState state = graphics.Save();
-            if (Invert)
-            {
-                graphics.SetClip(applyRect);
-                graphics.ExcludeClip(rect);
-            }
-
             if (GdiPlusApi.IsBlurPossible(blurRadius))
             {
                 GdiPlusApi.DrawWithBlur(graphics, applyBitmap, applyRect, null, null, blurRadius, false);
             }
             else
             {
-                using IFastBitmap fastBitmap = FastBitmap.CreateCloneOf(applyBitmap, applyRect);
-                ImageHelper.ApplyBoxBlur(fastBitmap, blurRadius);
-                fastBitmap.DrawTo(graphics, applyRect);
+                using (IFastBitmap fastBitmap = FastBitmap.CreateCloneOf(applyBitmap, applyRect))
+                {
+                    ImageHelper.ApplyBoxBlur(fastBitmap, blurRadius);
+                    fastBitmap.DrawTo(graphics, applyRect);
+                }
             }
-
-            graphics.Restore(state);
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/Filters/BrightnessFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/BrightnessFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -21,7 +21,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using Dapplo.Windows.Common.Structs;
 using Greenshot.Base.Core;
@@ -38,37 +37,13 @@ namespace Greenshot.Editor.Drawing.Filters
             AddField(GetType(), FieldType.BRIGHTNESS, 0.9d);
         }
 
-        /// <summary>
-        /// Implements the Apply code for the Brightness Filet
-        /// </summary>
-        /// <param name="graphics"></param>
-        /// <param name="applyBitmap"></param>
-        /// <param name="rect">NativeRect</param>
-        /// <param name="renderMode"></param>
-        public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
+        protected override void ApplyFilter(Graphics graphics, Bitmap applyBitmap, NativeRect applyRect, RenderMode renderMode)
         {
-            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-
-            if (applyRect.Width == 0 || applyRect.Height == 0)
-            {
-                // nothing to do
-                return;
-            }
-
-            GraphicsState state = graphics.Save();
-            if (Invert)
-            {
-                graphics.SetClip(applyRect);
-                graphics.ExcludeClip(rect);
-            }
-
             float brightness = GetFieldValueAsFloat(FieldType.BRIGHTNESS);
             using (ImageAttributes ia = ImageHelper.CreateAdjustAttributes(brightness, 1f, 1f))
             {
                 graphics.DrawImage(applyBitmap, applyRect, applyRect.X, applyRect.Y, applyRect.Width, applyRect.Height, GraphicsUnit.Pixel, ia);
             }
-
-            graphics.Restore(state);
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/Filters/GrayscaleFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/GrayscaleFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -21,10 +21,8 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using Dapplo.Windows.Common.Structs;
-using Greenshot.Base.Core;
 using Greenshot.Base.Interfaces.Drawing;
 
 namespace Greenshot.Editor.Drawing.Filters
@@ -35,57 +33,26 @@ namespace Greenshot.Editor.Drawing.Filters
     [Serializable()]
     public class GrayscaleFilter : AbstractFilter
     {
+        private static readonly ColorMatrix GrayscaleMatrix = new ColorMatrix(new[]
+        {
+            new[] { .3f, .3f, .3f, 0, 0 },
+            new[] { .59f, .59f, .59f, 0, 0 },
+            new[] { .11f, .11f, .11f, 0, 0 },
+            new float[] { 0, 0, 0, 1, 0 },
+            new float[] { 0, 0, 0, 0, 1 }
+        });
+
         public GrayscaleFilter(DrawableContainer parent) : base(parent)
         {
         }
 
-        public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
+        protected override void ApplyFilter(Graphics graphics, Bitmap applyBitmap, NativeRect applyRect, RenderMode renderMode)
         {
-            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-
-            if (applyRect.Width == 0 || applyRect.Height == 0)
-            {
-                // nothing to do
-                return;
-            }
-
-            GraphicsState state = graphics.Save();
-            if (Invert)
-            {
-                graphics.SetClip(applyRect);
-                graphics.ExcludeClip(rect);
-            }
-
-            ColorMatrix grayscaleMatrix = new ColorMatrix(new[]
-            {
-                new[]
-                {
-                    .3f, .3f, .3f, 0, 0
-                },
-                new[]
-                {
-                    .59f, .59f, .59f, 0, 0
-                },
-                new[]
-                {
-                    .11f, .11f, .11f, 0, 0
-                },
-                new float[]
-                {
-                    0, 0, 0, 1, 0
-                },
-                new float[]
-                {
-                    0, 0, 0, 0, 1
-                }
-            });
             using (ImageAttributes ia = new ImageAttributes())
             {
-                ia.SetColorMatrix(grayscaleMatrix);
+                ia.SetColorMatrix(GrayscaleMatrix);
                 graphics.DrawImage(applyBitmap, applyRect, applyRect.X, applyRect.Y, applyRect.Width, applyRect.Height, GraphicsUnit.Pixel, ia);
             }
-
-            graphics.Restore(state);
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/Filters/HighlightFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/HighlightFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -21,7 +21,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using Dapplo.Windows.Common.Structs;
 using Greenshot.Base.Core;
 using Greenshot.Base.Interfaces.Drawing;
@@ -40,30 +39,8 @@ namespace Greenshot.Editor.Drawing.Filters
             AddField(GetType(), FieldType.FILL_COLOR, Color.Yellow);
         }
 
-        /// <summary>
-        /// Implements the Apply code for the Brightness Filet
-        /// </summary>
-        /// <param name="graphics"></param>
-        /// <param name="applyBitmap"></param>
-        /// <param name="rect">NativeRect</param>
-        /// <param name="renderMode"></param>
-        public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
+        protected override void ApplyFilter(Graphics graphics, Bitmap applyBitmap, NativeRect applyRect, RenderMode renderMode)
         {
-            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-
-            if (applyRect.Width == 0 || applyRect.Height == 0)
-            {
-                // nothing to do
-                return;
-            }
-
-            GraphicsState state = graphics.Save();
-            if (Invert)
-            {
-                graphics.SetClip(applyRect);
-                graphics.ExcludeClip(rect);
-            }
-
             using (IFastBitmap fastBitmap = FastBitmap.CreateCloneOf(applyBitmap, applyRect))
             {
                 Color highlightColor = GetFieldValueAsColor(FieldType.FILL_COLOR);
@@ -79,8 +56,6 @@ namespace Greenshot.Editor.Drawing.Filters
 
                 fastBitmap.DrawTo(graphics, applyRect.Location);
             }
-
-            graphics.Restore(state);
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/Filters/IFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/IFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using Dapplo.Windows.Common.Structs;
@@ -30,6 +31,7 @@ namespace Greenshot.Editor.Drawing.Filters
     {
         DrawableContainer Parent { get; set; }
         void Apply(Graphics graphics, Bitmap bmp, NativeRect rect, RenderMode renderMode);
+        void Apply(Graphics graphics, Bitmap bmp, IEnumerable<NativeRect> rects, RenderMode renderMode);
         DrawableContainer GetParent();
         bool Invert { get; set; }
     }

--- a/src/Greenshot.Editor/Drawing/Filters/MagnifierFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/MagnifierFilter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Greenshot - a free and open source screenshot tool
  * Copyright (C) 2004-2026 Thomas Braun, Jens Klingen, Robin Krom
  * 
@@ -20,10 +20,10 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using Dapplo.Windows.Common.Structs;
-using Greenshot.Base.Core;
 using Greenshot.Base.Interfaces.Drawing;
 using Greenshot.Editor.Drawing.Fields;
 
@@ -42,33 +42,33 @@ namespace Greenshot.Editor.Drawing.Filters
 
         public override void Apply(Graphics graphics, Bitmap applyBitmap, NativeRect rect, RenderMode renderMode)
         {
-            var applyRect = ImageHelper.CreateIntersectRectangle(applyBitmap.Size, rect, Invert);
-
-            if (applyRect.Width == 0 || applyRect.Height == 0)
+            ApplyWithClipping(graphics, applyBitmap, new[] { rect }, applyRect =>
             {
-                // nothing to do
+                int magnificationFactor = GetFieldValueAsInt(FieldType.MAGNIFICATION_FACTOR);
+                graphics.SmoothingMode = SmoothingMode.None;
+                graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+                graphics.CompositingQuality = CompositingQuality.HighQuality;
+                graphics.PixelOffsetMode = PixelOffsetMode.None;
+                int halfWidth = rect.Width / 2;
+                int halfHeight = rect.Height / 2;
+                int newWidth = rect.Width / magnificationFactor;
+                int newHeight = rect.Height / magnificationFactor;
+                var source = new NativeRect(rect.X + halfWidth - newWidth / 2, rect.Y + halfHeight - newHeight / 2, newWidth, newHeight);
+                graphics.DrawImage(applyBitmap, rect, source, GraphicsUnit.Pixel);
+            });
+        }
+
+        public override void Apply(Graphics graphics, Bitmap applyBitmap, IEnumerable<NativeRect> rects, RenderMode renderMode)
+        {
+            if (rects == null)
+            {
                 return;
             }
 
-            int magnificationFactor = GetFieldValueAsInt(FieldType.MAGNIFICATION_FACTOR);
-            GraphicsState state = graphics.Save();
-            if (Invert)
+            foreach (var r in rects)
             {
-                graphics.SetClip(applyRect);
-                graphics.ExcludeClip(rect);
+                Apply(graphics, applyBitmap, r, renderMode);
             }
-
-            graphics.SmoothingMode = SmoothingMode.None;
-            graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
-            graphics.CompositingQuality = CompositingQuality.HighQuality;
-            graphics.PixelOffsetMode = PixelOffsetMode.None;
-            int halfWidth = rect.Width / 2;
-            int halfHeight = rect.Height / 2;
-            int newWidth = rect.Width / magnificationFactor;
-            int newHeight = rect.Height / magnificationFactor;
-            var source = new NativeRect(rect.X + halfWidth - newWidth / 2, rect.Y + halfHeight - newHeight / 2, newWidth, newHeight);
-            graphics.DrawImage(applyBitmap, rect, source, GraphicsUnit.Pixel);
-            graphics.Restore(state);
         }
     }
 }

--- a/src/Greenshot.Editor/Drawing/Filters/PixelizationFilter.cs
+++ b/src/Greenshot.Editor/Drawing/Filters/PixelizationFilter.cs
@@ -262,5 +262,18 @@ namespace Greenshot.Editor.Drawing.Filters
 
             dest.DrawTo(graphics, applyRect.Location);
         }
+
+        public override void Apply(Graphics graphics, Bitmap applyBitmap, IEnumerable<NativeRect> rects, RenderMode renderMode)
+        {
+            if (rects == null)
+            {
+                return;
+            }
+
+            foreach (var r in rects)
+            {
+                Apply(graphics, applyBitmap, r, renderMode);
+            }
+        }
     }
 }


### PR DESCRIPTION
This change makes it possible to draw the HighlightFilter or GrayscaleFilter only once for multiple selected areas, as #622 and #512 supposed to do, but in a single change looking at both requirements.

I really do not want to take away the great work that @FF-Brown and @Kissaki did on their PRs, but I wanted a single solution for the 2 filters. This is what I came up with.

Co-authored-by: @Kissaki 
Co-authored-by: @FF-Brown 