### PR TITLE
Add missing translation for StepLabel start value in Toolbar

### DIFF
--- a/.github/agents/translation-manager.agent.md
+++ b/.github/agents/translation-manager.agent.md
@@ -1,0 +1,8 @@
+---
+name: translation-manager
+description: Wrapper agent for Visual Studio integration of the translation manager.
+---
+
+This is only a wrapper agent file for Visual Studio integration.
+
+The complete translation-manager instructions are maintained in `.github/agents/translation-manager.md`. Read and follow that file for all translation-related work.

--- a/src/Greenshot/Languages/language-ar-SY.xml
+++ b/src/Greenshot/Languages/language-ar-SY.xml
@@ -217,5 +217,6 @@ ${hostname} اسم الحاسوب
 		<resource name="editor_fit">تمديد</resource>
 		<resource name="editor_pushout">توسيع الالتقاط ونقل العنصر إلى الخارج</resource>
 		<resource name="editor_snap">إرساء عند الحافة</resource>
+		<resource name="editor_counter_startvalue">قيمة البدء</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-ca-CA.xml
+++ b/src/Greenshot/Languages/language-ca-CA.xml
@@ -334,5 +334,6 @@ Malgrat això, encara es poden utilitzar totes les característiques de Greensho
 		<resource name="editor_fit">Estira</resource>
 		<resource name="editor_pushout">Amplia la captura i mou a fora</resource>
 		<resource name="editor_snap">Acobla a la vora</resource>
+		<resource name="editor_counter_startvalue">Valor inicial</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-cs-CZ.xml
+++ b/src/Greenshot/Languages/language-cs-CZ.xml
@@ -338,5 +338,6 @@ Všechny funkce Greenshotu jsou stále dostupné přímo z místní nabídky bez
 		<resource name="editor_fit">Roztáhnout</resource>
 		<resource name="editor_pushout">Rozšířit snímek a přesunout ven</resource>
 		<resource name="editor_snap">Přichytit k okraji</resource>
+		<resource name="editor_counter_startvalue">Počáteční hodnota</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-da-DK.xml
+++ b/src/Greenshot/Languages/language-da-DK.xml
@@ -608,5 +608,6 @@ tidspunktet, fx 11_58_32 (plus filendelsen angivet i indstillingerne).
   <resource name="editor_fit">Stræk</resource>
   <resource name="editor_pushout">Udvid optagelsen og flyt udenfor</resource>
   <resource name="editor_snap">Fastgør til kanten</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Startværdi</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-de-DE.xml
+++ b/src/Greenshot/Languages/language-de-DE.xml
@@ -342,5 +342,6 @@ Sie können aber auch alle Greenshot-Funktionen über das Kontextmenü des Green
 	<resource name="editor_fit">Strecken</resource>
 	<resource name="editor_pushout">Aufnahme vergrößern und nach außen verschieben</resource>
 	<resource name="editor_snap">Am Rand andocken</resource>
+		<resource name="editor_counter_startvalue">Startwert</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-de-x-franconia.xml
+++ b/src/Greenshot/Languages/language-de-x-franconia.xml
@@ -299,5 +299,6 @@ Wennsd mogsd, kannsd nadürlich a einfach es Gondexdmenü nehmen (des grüne G r
 	<resource name="editor_fit">Streckn</resource>
 	<resource name="editor_pushout">Aufnahme vergrößern und naus schiebn</resource>
 	<resource name="editor_snap">Am Rand andockn</resource>
+		<resource name="editor_counter_startvalue">Startwert</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-el-GR.xml
+++ b/src/Greenshot/Languages/language-el-GR.xml
@@ -314,5 +314,6 @@ ${hostname} Όνομα Υπολογιστή
 	<resource name="editor_fit">Τέντωμα</resource>
 	<resource name="editor_pushout">Επέκταση λήψης και μετακίνηση εκτός</resource>
 	<resource name="editor_snap">Προσάρτηση στην άκρη</resource>
+		<resource name="editor_counter_startvalue">Αρχική τιμή</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-en-US.xml
+++ b/src/Greenshot/Languages/language-en-US.xml
@@ -352,5 +352,6 @@ All Greenshot features still work directly from the tray icon context menu witho
     <resource name="editor_resize_height">Height</resource>
 	<resource name="settings_iconsize">Icon size</resource>
     
-  </resources>
+		<resource name="editor_counter_startvalue">Start value</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-es-ES.xml
+++ b/src/Greenshot/Languages/language-es-ES.xml
@@ -289,5 +289,6 @@ A pesar de esto, se sigue pudiendo utilizar todas las características de Greens
 	<resource name="editor_fit">Estirar</resource>
 	<resource name="editor_pushout">Ampliar captura y mover fuera</resource>
 	<resource name="editor_snap">Acoplar al borde</resource>
+		<resource name="editor_counter_startvalue">Valor inicial</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-et-EE.xml
+++ b/src/Greenshot/Languages/language-et-EE.xml
@@ -315,5 +315,6 @@ Kõik Greenshoti lisad töötavad süsteemisalvest ilma kiirklahvide olemasoluta
 	<resource name="editor_fit">Venita</resource>
 	<resource name="editor_pushout">Laienda jäädvustust ja liiguta väljapoole</resource>
 	<resource name="editor_snap">Dokki serva</resource>
+		<resource name="editor_counter_startvalue">Algväärtus</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-fa-IR.xml
+++ b/src/Greenshot/Languages/language-fa-IR.xml
@@ -237,5 +237,6 @@ Right-click here or press the Print-key.</resource>
 	<resource name="editor_fit">کشیدن</resource>
 	<resource name="editor_pushout">گسترش تصویر و انتقال به بیرون</resource>
 	<resource name="editor_snap">چسباندن به لبه</resource>
+		<resource name="editor_counter_startvalue">مقدار شروع</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-fi-FI.xml
+++ b/src/Greenshot/Languages/language-fi-FI.xml
@@ -217,5 +217,6 @@ Sammuta se ohjelma joka käyttäää print näppäintä. Vaihtoehtoisesti voit k
 	<resource name="editor_fit">Venytä</resource>
 	<resource name="editor_pushout">Laajenna kaappausta ja siirrä ulkopuolelle</resource>
 		<resource name="editor_snap">Telakoi reunaan</resource>
+		<resource name="editor_counter_startvalue">Aloitusarvo</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-fr-FR.xml
+++ b/src/Greenshot/Languages/language-fr-FR.xml
@@ -342,5 +342,6 @@ Toutes les fonctionnalités de Greenshot se lancent aussi directement depuis le 
 		<resource name="editor_fit">Étirer</resource>
 		<resource name="editor_pushout">Agrandir la capture et déplacer à l’extérieur</resource>
 		<resource name="editor_snap">Ancrer au bord</resource>
+		<resource name="editor_counter_startvalue">Valeur de départ</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-fr-QC.xml
+++ b/src/Greenshot/Languages/language-fr-QC.xml
@@ -283,5 +283,6 @@ Veuillez désactiver ce(s) logiciel(s) utilisant le bouton Impr.écran. Vous pou
 	<resource name="editor_fit">Étirer</resource>
 	<resource name="editor_pushout">Agrandir la capture et déplacer à l’extérieur</resource>
 	<resource name="editor_snap">Ancrer au bord</resource>
+		<resource name="editor_counter_startvalue">Valeur de départ</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-he-IL.xml
+++ b/src/Greenshot/Languages/language-he-IL.xml
@@ -224,5 +224,6 @@ ${hostname}  שם המחשב
 	<resource name="editor_fit">מתיחה</resource>
 	<resource name="editor_pushout">הרחב את הלכידה והזז החוצה</resource>
 	<resource name="editor_snap">הצמד לקצה</resource>
+		<resource name="editor_counter_startvalue">ערך התחלתי</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-hu-HU.xml
+++ b/src/Greenshot/Languages/language-hu-HU.xml
@@ -217,5 +217,6 @@ Kapcsolja ki a szotvert és használja PrintScrn billentyűt. Egyszerűen haszn�
 	<resource name="editor_fit">Nyújtás</resource>
 	<resource name="editor_pushout">Rögzített kép kiterjesztése és áthelyezés kívülre</resource>
 	<resource name="editor_snap">Igazítás a szélhez</resource>
+		<resource name="editor_counter_startvalue">Kezdőérték</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-id-ID.xml
+++ b/src/Greenshot/Languages/language-id-ID.xml
@@ -329,5 +329,6 @@ cont, 11_58_32 (ditambah ekstensi yang ditetapkan pada pengaturan)</resource>
 	<resource name="editor_fit">Regangkan</resource>
 	<resource name="editor_pushout">Perluas tangkapan dan pindahkan ke luar</resource>
 	<resource name="editor_snap">Tempelkan ke tepi</resource>
+		<resource name="editor_counter_startvalue">Nilai awal</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-it-IT.xml
+++ b/src/Greenshot/Languages/language-it-IT.xml
@@ -356,5 +356,6 @@ In alternativa alle scorciatoie di tastiera, tutte le funzioni di Greenshot sono
     <resource name="editor_fit">Allunga</resource>
     <resource name="editor_pushout">Espandi acquisizione e sposta all'esterno</resource>
     <resource name="editor_snap">Aggancia al bordo</resource>
+    <resource name="editor_counter_startvalue">Valore iniziale</resource>
     </resources>
 </language>

--- a/src/Greenshot/Languages/language-ja-JP.xml
+++ b/src/Greenshot/Languages/language-ja-JP.xml
@@ -338,5 +338,6 @@ ${hostname} コンピューター名
 	<resource name="editor_fit">引き伸ばす</resource>
 	<resource name="editor_pushout">キャプチャを拡張して外側へ移動</resource>
 	<resource name="editor_snap">端にドッキング</resource>
+		<resource name="editor_counter_startvalue">開始値</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-kab-DZ.xml
+++ b/src/Greenshot/Languages/language-kab-DZ.xml
@@ -330,5 +330,6 @@ Akk timahilin n Greenshot sttenkarent daɣen s srid seg umuɣ umniḍ n tignit n
 		<resource name="editor_fit">Ẓẓi</resource>
 		<resource name="editor_pushout">Snefli tuṭṭfa u semutti ɣer berra</resource>
 		<resource name="editor_snap">Senqed ɣer yiri</resource>
+		<resource name="editor_counter_startvalue">Azal n tazwara</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-ko-KR.xml
+++ b/src/Greenshot/Languages/language-ko-KR.xml
@@ -334,5 +334,6 @@ ${hostname} PC명
   <resource name="editor_fit">늘이기</resource>
   <resource name="editor_pushout">캡처를 확장하고 바깥쪽으로 이동</resource>
   <resource name="editor_snap">가장자리에 고정</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">시작 값</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-lt-LT.xml
+++ b/src/Greenshot/Languages/language-lt-LT.xml
@@ -214,5 +214,6 @@ kurios naudoja šiuos mygtukus. Arba galima naudoti komandas iš Greenshot progr
 	<resource name="editor_fit">Ištempti</resource>
 	<resource name="editor_pushout">Išplėsti fiksavimą ir perkelti už ribų</resource>
 	<resource name="editor_snap">Priglausti prie krašto</resource>
+		<resource name="editor_counter_startvalue">Pradinė reikšmė</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-lv-LV.xml
+++ b/src/Greenshot/Languages/language-lv-LV.xml
@@ -336,5 +336,6 @@ Arī bez karstiem taustiņiem visas darbības iespējams veikt izmantojot „Gre
   	<resource name="editor_fit">Izstiept</resource>
   	<resource name="editor_pushout">Paplašināt tveršanu un pārvietot ārpusē</resource>
   	<resource name="editor_snap">Piespiest pie malas</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Sākuma vērtība</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-nl-NL.xml
+++ b/src/Greenshot/Languages/language-nl-NL.xml
@@ -338,5 +338,6 @@ Alle Greenshot functies werken ook zonder sneltoetsen via het context menu.</res
 	<resource name="editor_fit">Uitrekken</resource>
 	<resource name="editor_pushout">Opname uitbreiden en naar buiten verplaatsen</resource>
 	<resource name="editor_snap">Aan rand vastmaken</resource>
+		<resource name="editor_counter_startvalue">Startwaarde</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-nn-NO.xml
+++ b/src/Greenshot/Languages/language-nn-NO.xml
@@ -282,5 +282,6 @@ Alle Greenshot-funksjonar er likevel tilgjengeleg via høgreklikkmenyen i varsli
 	<resource name="editor_fit">Strekk</resource>
 	<resource name="editor_pushout">Utvid opptaket og flytt utenfor</resource>
 	<resource name="editor_snap">Fest til kanten</resource>
+		<resource name="editor_counter_startvalue">Startverdi</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-pl-PL.xml
+++ b/src/Greenshot/Languages/language-pl-PL.xml
@@ -318,5 +318,6 @@ Proszę wyłączyć oprogramowanie korzystające z klawisza Print. Możliwe jest
 	<resource name="editor_fit">Rozciągnij</resource>
 	<resource name="editor_pushout">Rozszerz zrzut i przenieś na zewnątrz</resource>
 	<resource name="editor_snap">Przyciągnij do krawędzi</resource>
+		<resource name="editor_counter_startvalue">Wartość początkowa</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-pt-BR.xml
+++ b/src/Greenshot/Languages/language-pt-BR.xml
@@ -297,5 +297,6 @@
 	<resource name="editor_fit">Esticar</resource>
 	<resource name="editor_pushout">Expandir a captura e mover para fora</resource>
 	<resource name="editor_snap">Encaixar à borda</resource>
+		<resource name="editor_counter_startvalue">Valor inicial</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-pt-PT.xml
+++ b/src/Greenshot/Languages/language-pt-PT.xml
@@ -336,6 +336,7 @@ Todas as funcionalidades do Greenshot funcionam directamente através do menu de
   <resource name="editor_fit">Esticar</resource>
   <resource name="editor_pushout">Expandir a captura e mover para fora</resource>
   <resource name="editor_snap">Encaixar à margem</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Valor inicial</resource>
+	</resources>
 </language>
 	

--- a/src/Greenshot/Languages/language-ro-RO.xml
+++ b/src/Greenshot/Languages/language-ro-RO.xml
@@ -607,5 +607,6 @@ timpul curent, ex. 11_58_32 (plus extensia fișierului definită în setări)
   <resource name="editor_fit">Întinde</resource>
   <resource name="editor_pushout">Extinde captura și mută în exterior</resource>
   <resource name="editor_snap">Fixează la margine</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Valoare inițială</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-ru-RU.xml
+++ b/src/Greenshot/Languages/language-ru-RU.xml
@@ -318,5 +318,6 @@ ${hostname} Имя ПК
 	<resource name="editor_fit">Растянуть</resource>
 	<resource name="editor_pushout">Расширить снимок и переместить наружу</resource>
 	<resource name="editor_snap">Прикрепить к краю</resource>
+		<resource name="editor_counter_startvalue">Начальное значение</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-sk-SK.xml
+++ b/src/Greenshot/Languages/language-sk-SK.xml
@@ -298,5 +298,6 @@ Prosím deaktivujte iný software využívajúci PrintScreen tlačidlo. Môžete
 	<resource name="editor_fit">Roztiahnuť</resource>
 	<resource name="editor_pushout">Rozšíriť snímku a presunúť von</resource>
 	<resource name="editor_snap">Prichytiť k okraju</resource>
+		<resource name="editor_counter_startvalue">Počiatočná hodnota</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-sl-SI.xml
+++ b/src/Greenshot/Languages/language-sl-SI.xml
@@ -268,5 +268,6 @@ Vse funkcije Greenshota še vedno delujejo preko ikone za hitri zagon.</resource
 	<resource name="editor_fit">Raztegni</resource>
 	<resource name="editor_pushout">Razširi zajem in premakni navzven</resource>
 	<resource name="editor_snap">Pripni na rob</resource>
+		<resource name="editor_counter_startvalue">Začetna vrednost</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-sr-RS.xml
+++ b/src/Greenshot/Languages/language-sr-RS.xml
@@ -286,5 +286,6 @@ ${hostname} назив рачунара
 	<resource name="editor_fit">Развуци</resource>
 	<resource name="editor_pushout">Прошири снимак и премести ван</resource>
 	<resource name="editor_snap">Прикачи на ивицу</resource>
+		<resource name="editor_counter_startvalue">Почетна вредност</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-sv-SE.xml
+++ b/src/Greenshot/Languages/language-sv-SE.xml
@@ -343,5 +343,6 @@ Alla Greenshots funktioner fungerar fortfarande från snabbmenyn i aktivitetsfä
 	<resource name="editor_fit">Sträck ut</resource>
 	<resource name="editor_pushout">Utöka skärmdumpen och flytta utanför</resource>
 	<resource name="editor_snap">Fäst vid kanten</resource>
+		<resource name="editor_counter_startvalue">Startvärde</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-tr-TR.xml
+++ b/src/Greenshot/Languages/language-tr-TR.xml
@@ -340,5 +340,6 @@ Greenshot özellikleri, kısayol tuşları olmadan sistem tepsisi menüsünden k
   <resource name="editor_fit">Esnet</resource>
   <resource name="editor_pushout">Yakalamayı genişlet ve dışarı taşı</resource>
   <resource name="editor_snap">Kenara tuttur</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Başlangıç değeri</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-uk-UA.xml
+++ b/src/Greenshot/Languages/language-uk-UA.xml
@@ -336,5 +336,6 @@ ${hostname} назва комп’ютера
   <resource name="editor_fit">Розтягнути</resource>
   <resource name="editor_pushout">Розширити знімок і перемістити назовні</resource>
   <resource name="editor_snap">Прикріпити до краю</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Початкове значення</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-va-VA.xml
+++ b/src/Greenshot/Languages/language-va-VA.xml
@@ -349,5 +349,6 @@ Totes les funcions de Greenshot continuen disponibles directament des del menú 
   <resource name="editor_fit">Estirar</resource>
   <resource name="editor_pushout">Amplia la captura i mou cap a fora</resource>
   <resource name="editor_snap">Acoblar a la vora</resource>
-  </resources>
+	<resource name="editor_counter_startvalue">Valor inicial</resource>
+	</resources>
 </language>

--- a/src/Greenshot/Languages/language-vi-VN.xml
+++ b/src/Greenshot/Languages/language-vi-VN.xml
@@ -216,5 +216,6 @@
 	<resource name="editor_fit">Kéo giãn</resource>
 	<resource name="editor_pushout">Mở rộng ảnh chụp và di chuyển ra ngoài</resource>
 	<resource name="editor_snap">Neo vào cạnh</resource>
+		<resource name="editor_counter_startvalue">Giá trị bắt đầu</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-zh-CN.xml
+++ b/src/Greenshot/Languages/language-zh-CN.xml
@@ -320,5 +320,6 @@ Alt+Print	抓取程序窗口（如果没有选择交互式抓取方式，将会�
 	<resource name="editor_fit">拉伸</resource>
 	<resource name="editor_pushout">扩展截图并移至外部</resource>
 	<resource name="editor_snap">停靠至边缘</resource>
+		<resource name="editor_counter_startvalue">起始值</resource>
 	</resources>
 </language>

--- a/src/Greenshot/Languages/language-zh-TW.xml
+++ b/src/Greenshot/Languages/language-zh-TW.xml
@@ -337,5 +337,6 @@ Greenshot 所有功能仍然可以直接從通知區圖示的內容功能表動�
 	<resource name="editor_fit">拉伸</resource>
 	<resource name="editor_pushout">擴展擷取範圍並移至外側</resource>
 	<resource name="editor_snap">停駐至邊緣</resource>
+		<resource name="editor_counter_startvalue">起始值</resource>
 	</resources>
 </language>


### PR DESCRIPTION
After the changes in #1130 a placeholder text was displayed for the editor counter start field of `StepLabel`.

Agents in Visual Studio must be named with the extension ‘agent.md’ so that they can be selected in the UI. That is why I have added a wrapper file for the existing ‘translation-manager.md’ file.
