### PR TITLE
Fix for loading .greenshot file

### DIFF
--- a/src/Greenshot.Base/Pipeline/Sources/FileCaptureSource.cs
+++ b/src/Greenshot.Base/Pipeline/Sources/FileCaptureSource.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Greenshot.Base.Core;
+using Greenshot.Base.Core.Enums;
 using Greenshot.Base.Interfaces;
 using log4net;
 
@@ -69,6 +70,19 @@ namespace Greenshot.Base.Pipeline.Sources
                 capture.CaptureDetails.AddMetaData("source", "file");
 
                 var payload = new CapturePayload(capture);
+
+                // dirty hack, if we open .greenshot file we have to load the file twice 
+                // we need an instance of a Surface for loading, but only the CapturePayload can create this
+                // and the CapturePayload need a Capture with an Image
+                if (filename.ToLower().EndsWith("." + OutputFormat.greenshot))
+                {
+                    payload.EnsureSurface();
+                    if (payload.Surface is not null)
+                    {
+                        payload.Surface = ImageIO.LoadGreenshotSurface(filename, payload.Surface);
+                    }
+                }
+
                 return Task.FromResult<ICapturePayload>(payload);
             }
             catch (Exception ex)


### PR DESCRIPTION
Since v1.4.209 greenshot files have not been loading properly. Greenshot loads it only as image.

Before loading the file we need an instance of a `ISurface`.  But only the `CapturePayload` can create it internally and `CapturePayload` needs an Image.
So i added a hack wich loads the file twice.

I know that the main problem is that the Surface is defined in the Greenshot.Editor project and it is a Windows.Forms control.
And Greenshot.Base should not reference Greenshot.Editor.

In #638  i had the same problem and created an internal domain representation [GreenshotFile](https://github.com/Christian-Schulz/greenshot/blob/feature/new_greenshot_file_format_v2/src/Greenshot.Editor/FileFormat/GreenshotFile.cs) for all data from a Surface.
After loading the file into the domain object it is converted to a Surface [here](https://github.com/Christian-Schulz/greenshot/blob/413471def47c25492e2e6e7d5460b16cb1ae4deb/src/Greenshot.Editor/FileFormat/GreenshotFileVersionHandler.cs#L205)

Such similar domain object could be replace the ISurface in CapturePayload

@Lakritzator what are your thought?